### PR TITLE
Add interface to allow regalloc to query proper slot number for combined slot

### DIFF
--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -1972,6 +1972,10 @@ impl regalloc::Function for Func {
     None
   }
 
+  fn combined_slot(first_slot: SpillSlot, _num_slots: u32) -> SpillSlot {
+      first_slot
+  }
+
   fn func_liveins(&self) -> Set<RealReg> {
     Set::empty()
   }

--- a/lib/src/interface.rs
+++ b/lib/src/interface.rs
@@ -271,6 +271,18 @@ pub trait Function {
     &self, insn: &Self::Inst, reg: VirtualReg, slot: SpillSlot,
   ) -> Option<Self::Inst>;
 
+  /// Return the slot number used to refer to a "combined slot".
+  /// When the number of spill slots required to spill a given
+  /// register class is greater than one, we use combined slots;
+  /// it is a client--defined detail which slot
+  /// number we use to refer to this combined slot in spill and
+  /// reload instructions. This function returns the value that
+  /// should be used.
+  ///
+  /// The slot given will be aligned to `num_slots`, and `num_slots`
+  /// will be a power of two.
+  fn combined_slot(first_slot: SpillSlot, num_slots: u32) -> SpillSlot;
+
   // ----------------------------------------------------------
   // Function liveins, liveouts, and direct-mode real registers
   // ----------------------------------------------------------


### PR DESCRIPTION
As per discussion with @julian-seward1 on Zulip, this allows the register allocator to query the client: when it needs to use an N-slot space (e.g., two slots, for a 128-bit vector reg), it needs to know how to refer to this combined slot in spill and reload instructions. Depending on the underlying address computation / stack frame layout that the client uses, this may be `base` (first constituent slot), `base + len - 1` (last constituent slot), or maybe even something else.