### PR TITLE
Minor external interface tidying

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,7 +15,7 @@ mod backtracking;
 mod checker;
 mod data_structures;
 mod inst_stream;
-pub mod interface;
+mod interface;
 mod linear_scan;
 mod trees_maps_sets;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,7 +2,7 @@
  * vim: set ts=8 sts=2 et sw=2 tw=80:
 */
 
-//! Main file / top-level module for minira library.
+//! Main file / top-level module for regalloc library.
 
 // Make the analysis module public for fuzzing.
 #[cfg(feature = "fuzzing")]


### PR DESCRIPTION
This updates a comment, and tweaks the public interface to just export the contents of the `interface` rather than also `interface` itself, to make the front page of https://docs.rs/regalloc/ more informative.