### PR TITLE
Fixes #43: Use markdown code comments for code;

### DIFF
--- a/bin/test_cases.rs
+++ b/bin/test_cases.rs
@@ -2,7 +2,7 @@
  * vim: set ts=8 sts=2 et sw=2 tw=80:
 */
 
-/// Test cases.  The list of them is right at the bottom, function |find_Func|.
+/// Test cases.  The list of them is right at the bottom, function `find_Func`.
 /// Add new ones there.
 use regalloc::{Reg, RegClass};
 

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -343,7 +343,7 @@ pub enum Inst {
         op: BinOp,
         dst: Reg,
         src_right: RI,
-    }, // "mod" semantics for |dst|
+    }, // "mod" semantics for `dst`
     BinOpF {
         op: BinOpF,
         dst: Reg,
@@ -853,12 +853,12 @@ impl Inst {
     // respectively.
     //
     // Be careful here.  If an instruction really modifies a register -- as is
-    // typical for x86 -- that register needs to be in the |mod| set, and not in
-    // the |def| and |use| sets.  *Any* mistake in describing register uses here
+    // typical for x86 -- that register needs to be in the `mod` set, and not in
+    // the `def` and `use` sets.  *Any* mistake in describing register uses here
     // will almost certainly lead to incorrect register allocations.
     //
-    // Also the following must hold: the union of |def| and |use| must be
-    // disjoint from |mod|.
+    // Also the following must hold: the union of `def` and `use` must be
+    // disjoint from `mod`.
     pub fn get_reg_usage(&self, collector: &mut RegUsageCollector) {
         match self {
             Inst::NopZ {} => {}
@@ -1645,7 +1645,7 @@ pub struct Func {
     pub num_virtual_regs: u32,
     pub insns: TypedIxVec<InstIx, Inst>, // indexed by InstIx
 
-    // Note that |blocks| must be in order of increasing |Block::start|
+    // Note that `blocks` must be in order of increasing `Block::start`
     // fields.  Code that wants to traverse the blocks in some other order
     // must represent the ordering some other way; rearranging Func::blocks is
     // not allowed.
@@ -1723,7 +1723,7 @@ impl Func {
             for i in b.start.get()..b.start.get() + b.len {
                 let iix = InstIx::new(i);
 
-                // Get the use, def and mod sets for |self.insns[iix]|.  This is a bit
+                // Get the use, def and mod sets for `self.insns[iix]`.  This is a bit
                 // awkward since we don't have the library's internal convenience
                 // functions available here.
                 let mut ru_vecs = RegUsageCollector::get_empty_RegVecs_TEST_FRAMEWORK_ONLY(false);
@@ -2322,7 +2322,7 @@ impl regalloc::Function for Func {
     }
 }
 
-/// Create a universe for testing, with nI32 |I32| class regs and nF32 |F32|
+/// Create a universe for testing, with nI32 `I32` class regs and nF32 `F32`
 /// class regs.
 pub fn make_universe(num_i32: usize, num_f32: usize) -> RealRegUniverse {
     let total_regs = num_i32 + num_f32;

--- a/lib/src/avl_tree.rs
+++ b/lib/src/avl_tree.rs
@@ -51,7 +51,7 @@ pub struct AVLTree<T> {
     // The freelist head.  This is a list of available entries.  Each item on
     // the freelist must have its .tag be AVLTag::Free, and will use its .left
     // field as the link to the next freelist item.  A freelist link value of
-    // AVL_NULL denotes the end of the list.  If |freelist| itself is AVL_NULL
+    // AVL_NULL denotes the end of the list.  If `freelist` itself is AVL_NULL
     // then the list is empty.
     freelist: u32,
     // Last but not least, the root node.
@@ -177,7 +177,7 @@ impl<T: Copy + PartialOrd> AVLTree<T> {
         new_root
     }
 
-    // Private function: leftgrown: helper function for |insert|
+    // Private function: leftgrown: helper function for `insert`
     //
     //  Parameters:
     //
@@ -249,7 +249,7 @@ impl<T: Copy + PartialOrd> AVLTree<T> {
         }
     }
 
-    // Private function: rightgrown: helper function for |insert|
+    // Private function: rightgrown: helper function for `insert`
     //
     //  See leftgrown for details.
     fn rightgrown(&mut self, mut root: u32) -> (u32, AVLRes) {
@@ -308,7 +308,7 @@ impl<T: Copy + PartialOrd> AVLTree<T> {
     //
     //  Parameters:
     //
-    //    root        Root of the tree in whch to insert |d|.
+    //    root        Root of the tree in whch to insert `d`.
     //
     //    item        Item to be inserted.
     //
@@ -784,7 +784,7 @@ impl<T: Copy + PartialOrd> AVLTree<T> {
     // then comparison is done directly using PartialOrd for the T values.
     //
     // If this is Some(cmp), then comparison is done by passing the two T values
-    // to |cmp|.  In this case, the routines will complain (panic) if |cmp|
+    // to `cmp`.  In this case, the routines will complain (panic) if `cmp`
     // indicates that its arguments are unordered.
 
     // Insert a value in the tree.  Returns true if an insert happened, false if
@@ -975,7 +975,7 @@ mod avl_tree_test_utils {
         for i in univ_min..univ_max {
             let should_be_in = should_be_in_tree.contains(i);
 
-            // Look it up with a null comparator (so |contains| compares
+            // Look it up with a null comparator (so `contains` compares
             // directly)
             let is_in = tree.contains::<fn(u32, u32) -> Option<Ordering>>(i, None);
             assert!(is_in == should_be_in);

--- a/lib/src/backtracking.rs
+++ b/lib/src/backtracking.rs
@@ -36,16 +36,16 @@ const CROSSCHECK_CM: bool = false;
 // members of a VirtualRange group to the same spill slot, so that moves
 // between two spilled members of the same group can be turned into no-ops.
 //
-// All of the |size| metrics in this bit are in terms of "logical spill slot
-// units", per the interface's description for |get_spillslot_size|.
+// All of the `size` metrics in this bit are in terms of "logical spill slot
+// units", per the interface's description for `get_spillslot_size`.
 
 // We keep one of these for every "logical spill slot" in use.
 enum LogicalSpillSlot {
-    // This slot is in use and can hold values of size |size| (only).  Note that
-    // |InUse| may only appear in |SpillSlotAllocator::slots| positions that
-    // have indices that are 0 % |size|.  Furthermore, after such an entry in
-    // |SpillSlotAllocator::slots|, the next |size| - 1 entries must be
-    // |Unavail|.  This is a hard invariant, violation of which will cause
+    // This slot is in use and can hold values of size `size` (only).  Note that
+    // `InUse` may only appear in `SpillSlotAllocator::slots` positions that
+    // have indices that are 0 % `size`.  Furthermore, after such an entry in
+    // `SpillSlotAllocator::slots`, the next `size` - 1 entries must be
+    // `Unavail`.  This is a hard invariant, violation of which will cause
     // overlapping spill slots and potential chaos.
     InUse {
         size: u32,
@@ -53,7 +53,7 @@ enum LogicalSpillSlot {
     },
     // This slot is unavailable, as described above.  It's unavailable because
     // it holds some part of the values associated with the nearest lower
-    // numbered entry which isn't |Unavail|, and that entry must be an |InUse|
+    // numbered entry which isn't `Unavail`, and that entry must be an `InUse`
     // entry.
     Unavail,
 }
@@ -98,13 +98,13 @@ fn cmp_tree_entries_for_SpillSlotAllocator(
 }
 
 // HELPER FUNCTION
-// Find out whether it is possible to add all of |frags| to |tree|.  Returns
+// Find out whether it is possible to add all of `frags` to `tree`.  Returns
 // true if possible, false if not.  This routine relies on the fact that
 // SortedFrags is non-overlapping.  However, this is a bit subtle.  We know
-// that both |tree| and |frags| individually are non-overlapping, but there's
-// no guarantee that elements of |frags| don't overlap |tree|.  Hence we have
-// to do a custom walk of |tree| to check for overlap; we can't just use
-// |AVLTree::contains|.
+// that both `tree` and `frags` individually are non-overlapping, but there's
+// no guarantee that elements of `frags` don't overlap `tree`.  Hence we have
+// to do a custom walk of `tree` to check for overlap; we can't just use
+// `AVLTree::contains`.
 fn ssal_is_add_possible(
     tree: &AVLTree<RangeFragIx>,
     frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
@@ -112,7 +112,7 @@ fn ssal_is_add_possible(
 ) -> bool {
     // Figure out whether all the frags will go in.
     for fix in &frags.frag_ixs {
-        // BEGIN check |fix| for any overlap against |tree|.
+        // BEGIN check `fix` for any overlap against `tree`.
         let frag = &frag_env[*fix];
         let mut root = tree.root;
         while root != AVL_NULL {
@@ -120,26 +120,26 @@ fn ssal_is_add_possible(
             let root_fix = root_node.item;
             let root_frag = &frag_env[root_fix];
             if frag.last < root_frag.first {
-                // |frag| is entirely to the left of the |root|.  So there's no
+                // `frag` is entirely to the left of the `root`.  So there's no
                 // overlap with root.  Continue by inspecting the left subtree.
                 root = root_node.left;
             } else if root_frag.last < frag.first {
                 // Ditto for the right subtree.
                 root = root_node.right;
             } else {
-                // |frag| overlaps the |root|.  Give up.
+                // `frag` overlaps the `root`.  Give up.
                 return false;
             }
         }
-        // END check |fix| for any overlap against |tree|.
-        // |fix| doesn't overlap.  Move on to the next one.
+        // END check `fix` for any overlap against `tree`.
+        // `fix` doesn't overlap.  Move on to the next one.
     }
     true
 }
 
 // HELPER FUNCTION
-// Try to add all of |frags| to |tree|.  Return |true| if possible, |false| if
-// not possible.  If |false| is returned, |tree| is unchanged (this is
+// Try to add all of `frags` to `tree`.  Return `true` if possible, `false` if
+// not possible.  If `false` is returned, `tree` is unchanged (this is
 // important).  This routine relies on the fact that SortedFrags is
 // non-overlapping.
 fn ssal_add_if_possible(
@@ -189,7 +189,7 @@ impl SpillSlotAllocator {
             size: req_size,
             tree,
         });
-        // And now "block out subsequent slots that |req_size| implies.
+        // And now "block out subsequent slots that `req_size` implies.
         // viz: req_size == 1  ->  block out 0 more
         // viz: req_size == 2  ->  block out 1 more
         // viz: req_size == 4  ->  block out 3 more
@@ -202,8 +202,8 @@ impl SpillSlotAllocator {
         res
     }
 
-    // Allocate spill slots for all the VirtualRanges in |vlrix|s eclass,
-    // including |vlrix| itself.  Since we are allocating spill slots for
+    // Allocate spill slots for all the VirtualRanges in `vlrix`s eclass,
+    // including `vlrix` itself.  Since we are allocating spill slots for
     // complete eclasses at once, none of the members of the class should
     // currently have any allocation.  This routine will try to allocate all
     // class members the same slot, but it can only guarantee to do so if the
@@ -266,7 +266,7 @@ impl SpillSlotAllocator {
             let tree = &cand_slot.get_tree();
             assert!(mb_chosen_slotno.is_none());
 
-            // BEGIN see if |cand_slot| can hold all eclass members individually
+            // BEGIN see if `cand_slot` can hold all eclass members individually
             let mut all_cands_fit_individually = true;
             for cand_vlrix in vlrEquivClasses.equiv_class_elems_iter(vlrix) {
                 let cand_vlr = &vlr_env[cand_vlrix];
@@ -276,12 +276,12 @@ impl SpillSlotAllocator {
                     break;
                 }
             }
-            // END see if |cand_slot| can hold all eclass members individually
+            // END see if `cand_slot` can hold all eclass members individually
             if !all_cands_fit_individually {
                 continue 'pass1_search_existing_slots;
             }
 
-            // Ok.  All eclass members will fit individually in |cand_slot_no|.
+            // Ok.  All eclass members will fit individually in `cand_slot_no`.
             mb_chosen_slotno = Some(cand_slot_no);
             break;
         } /* 'pass1_search_existing_slots */
@@ -308,7 +308,7 @@ impl SpillSlotAllocator {
                 vlr_slot_env[cand_vlrix] = Some(SpillSlot::new(chosen_slotno));
                 continue 'pass2_per_equiv_class;
             }
-            // It won't fit in |chosen_slotno|, so try somewhere (anywhere) else.
+            // It won't fit in `chosen_slotno`, so try somewhere (anywhere) else.
             for alt_slotno in 0..self.slots.len() as u32 {
                 let alt_slot = &self.slots[alt_slotno as usize];
                 if !alt_slot.is_InUse() {
@@ -439,7 +439,7 @@ fn do_coalescing_analysis<F: Function>(
     for (vlr, n) in vlr_env.iter().zip(0..) {
         let vlrix = VirtualRangeIx::new(n);
         let vreg: VirtualReg = vlr.vreg;
-        // Now we know that there's a VLR |vlr| that is for VReg |vreg|.  Update
+        // Now we know that there's a VLR `vlr` that is for VReg `vreg`.  Update
         // the inverse mapping accordingly.  That may involve resizing it, since
         // we have no idea of the order in which we will first encounter VRegs.
         // By contrast, we know we are stepping sequentially through the VLR
@@ -490,17 +490,17 @@ fn do_coalescing_analysis<F: Function>(
         for fix in &frags.frag_ixs {
           let frag = &frag_env[*fix];
           if xxIsLastUse {
-            // We're checking to see if |vreg| has a last use in this block
+            // We're checking to see if `vreg` has a last use in this block
             // (well, technically, a fragment end in the block; we don't care if
             // it is later redefined in the same block) .. anyway ..
-            // We're checking to see if |vreg| has a last use in this block
-            // at |iix|.u
+            // We're checking to see if `vreg` has a last use in this block
+            // at `iix`.u
             if frag.last == InstPoint::new_use(iix) {
               return Some(*vlrix);
             }
           } else {
-            // We're checking to see if |vreg| has a first def in this block
-            // at |iix|.d
+            // We're checking to see if `vreg` has a first def in this block
+            // at `iix`.d
             if frag.first == InstPoint::new_def(iix) {
               return Some(*vlrix);
             }
@@ -522,14 +522,14 @@ fn do_coalescing_analysis<F: Function>(
         for fix in &frags.frag_ixs {
           let frag = &frag_env[*fix];
           if xxIsLastUse {
-            // We're checking to see if |rreg| has a last use in this block
-            // at |iix|.u
+            // We're checking to see if `rreg` has a last use in this block
+            // at `iix`.u
             if frag.last == InstPoint::new_use(iix) {
               return Some(*rlrix);
             }
           } else {
-            // We're checking to see if |rreg| has a first def in this block
-            // at |iix|.d
+            // We're checking to see if `rreg` has a first def in this block
+            // at `iix`.d
             if frag.first == InstPoint::new_def(iix) {
               return Some(*rlrix);
             }
@@ -558,12 +558,12 @@ fn do_coalescing_analysis<F: Function>(
                     // It might seem strange to assert that defs_len is <= 1 rather than
                     // == 1.  But -- as fuzzing shows -- it might be that the
                     // destination of a copy is a real reg that is one of the
-                    // RealRegUniverse |suggested_scratch| registers.  It is allowable
+                    // RealRegUniverse `suggested_scratch` registers.  It is allowable
                     // for such a register to be defined, but not used or modified.
                     // However, sanitisation will ensure it is not present in any of the
                     // three register sets.  Hence the assertions and the following
                     // conditional block.  If any of the following five assertions fail,
-                    // the client's |is_move| is probably lying to us.
+                    // the client's `is_move` is probably lying to us.
                     assert!(iix_bounds.uses_len == 1);
                     assert!(iix_bounds.defs_len <= 1);
                     assert!(iix_bounds.mods_len == 0);
@@ -685,33 +685,33 @@ fn do_coalescing_analysis<F: Function>(
 }
 
 //=============================================================================
-// The as-yet-unallocated VirtualReg LR prio queue, |VirtualRangePrioQ|.
+// The as-yet-unallocated VirtualReg LR prio queue, `VirtualRangePrioQ`.
 //
 // Relevant methods are parameterised by a VirtualRange env.
 
-// What we seek to do with |VirtualRangePrioQ| is to implement a priority
+// What we seek to do with `VirtualRangePrioQ` is to implement a priority
 // queue of as-yet unallocated virtual live ranges.  For each iteration of the
 // main allocation loop, we pull out the highest-priority unallocated
 // VirtualRange, and either allocate it (somehow), or spill it.
 //
 // The Rust standard type BinaryHeap gives us an efficient way to implement
 // the priority queue.  However, it requires that the queue items supply the
-// necessary cost-comparisons by implementing |Ord| on that type.  Hence we
+// necessary cost-comparisons by implementing `Ord` on that type.  Hence we
 // have to wrap up the items we fundamentally want in the queue, viz,
-// |VirtualRangeIx|, into a new type |VirtualRangeIxAndSize| that also carries
-// the relevant cost field, |size|.  Then we implement |Ord| for
-// |VirtualRangeIxAndSize| so as to only look at the |size| fields.
+// `VirtualRangeIx`, into a new type `VirtualRangeIxAndSize` that also carries
+// the relevant cost field, `size`.  Then we implement `Ord` for
+// `VirtualRangeIxAndSize` so as to only look at the `size` fields.
 //
 // There is a small twist, however.  Most virtual ranges are small and so will
-// have a small |size| field (less than 20, let's say).  For such cases,
-// |BinaryHeap| will presumably choose between contenders with the same |size|
+// have a small `size` field (less than 20, let's say).  For such cases,
+// `BinaryHeap` will presumably choose between contenders with the same `size`
 // field in some arbitrary way.  This has two disadvantages:
 //
 // * it makes the exact allocation order, and hence allocation results,
-//   dependent on |BinaryHeap|'s arbitrary-choice scheme.  This seems
-//   undesirable, and given recent shenanigans resulting from |HashMap| being
+//   dependent on `BinaryHeap`'s arbitrary-choice scheme.  This seems
+//   undesirable, and given recent shenanigans resulting from `HashMap` being
 //   nondeterministic even in a single-threaded scenario, I don't entirely
-//   trust |BinaryHeap| even to be deterministic.
+//   trust `BinaryHeap` even to be deterministic.
 //
 // * experimentation with the "qsort" test case shows that breaking ties by
 //   selecting the entry that has been in the queue the longest, rather than
@@ -719,13 +719,13 @@ fn do_coalescing_analysis<F: Function>(
 //   spilling) in spill-heavy situations (where there are few registers).
 //   When there is not much spilling, it makes no difference.
 //
-// For these reasons, |VirtualRangeIxAndSize| also contains a |tiebreaker|
-// field.  The |VirtualRangePrioQ| logic gives a different value of this for
-// each |VirtualRangeIxAndSize| it creates.  These numbers start off at 2^32-1
+// For these reasons, `VirtualRangeIxAndSize` also contains a `tiebreaker`
+// field.  The `VirtualRangePrioQ` logic gives a different value of this for
+// each `VirtualRangeIxAndSize` it creates.  These numbers start off at 2^32-1
 // and decrease towards zero.  They are used as a secondary comparison key in
-// the case where the |size| fields are equal.  The effect is that (1)
+// the case where the `size` fields are equal.  The effect is that (1)
 // tiebreaking is made completely deterministic, and (2) it breaks ties in
-// favour of the oldest entry (since that will have the highest |tiebreaker|
+// favour of the oldest entry (since that will have the highest `tiebreaker`
 // field).
 //
 // The tiebreaker field will wrap around when it hits zero, but that can only
@@ -735,7 +735,7 @@ fn do_coalescing_analysis<F: Function>(
 // the correctness of the allocations.
 
 // Wrap up a VirtualRangeIx and its size, so that we can implement Ord for it
-// on the basis of the |size| and |tiebreaker| fields.
+// on the basis of the `size` and `tiebreaker` fields.
 //
 // NB! Do not derive {,Partial}{Eq,Ord} for this.  It has its own custom
 // implementations.
@@ -818,8 +818,8 @@ impl VirtualRangePrioQ {
         self.heap.push(to_add);
     }
 
-    // Look in |unallocated| to locate the entry referencing the VirtualRange
-    // with the largest |size| value.  Remove the ref from |unallocated| and
+    // Look in `unallocated` to locate the entry referencing the VirtualRange
+    // with the largest `size` value.  Remove the ref from `unallocated` and
     // return the VLRIx for said entry.
     #[inline(never)]
     fn get_longest_VirtualRange(&mut self) -> Option<VirtualRangeIx> {
@@ -856,7 +856,7 @@ impl VirtualRangePrioQ {
 
 // Something that pairs a fragment index with the index of the virtual range
 // to which this fragment conceptually "belongs", at least for the purposes of
-// this commitment map.  Alternatively, the |vlrix| field may be None, which
+// this commitment map.  Alternatively, the `vlrix` field may be None, which
 // indicates that the associated fragment belongs to a real-reg live range and
 // is therefore non-evictable.
 //
@@ -1159,7 +1159,7 @@ impl CommitmentMapFAST {
 // The per-real-register state
 //
 // Relevant methods are expected to be parameterised by the same VirtualRange
-// env as used in calls to |VirtualRangePrioQ|.
+// env as used in calls to `VirtualRangePrioQ`.
 
 struct PerRealReg {
     // The current committed fragments for this RealReg.
@@ -1167,9 +1167,9 @@ struct PerRealReg {
     committedFAST: CommitmentMapFAST,
 
     // The set of VirtualRanges which have been assigned to this RealReg.  The
-    // union of their frags will be equal to |committed| only if this RealReg
+    // union of their frags will be equal to `committed` only if this RealReg
     // has no RealRanges.  If this RealReg does have RealRanges the
-    // aforementioned union will be exactly the subset of |committed| not used
+    // aforementioned union will be exactly the subset of `committed` not used
     // by the RealRanges.
     vlrixs_assigned: Set<VirtualRangeIx>,
 }
@@ -1189,8 +1189,8 @@ impl PerRealReg {
         fenv: &TypedIxVec<RangeFragIx, RangeFrag>,
         vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
     ) {
-        // Commit this register to |to_add|, irrevocably.  Don't add it to
-        // |vlrixs_assigned| since we will never want to later evict the
+        // Commit this register to `to_add`, irrevocably.  Don't add it to
+        // `vlrixs_assigned` since we will never want to later evict the
         // assignment.
         self.committedFAST
             .add(&to_add.sorted_frags, None, fenv, vlr_env);
@@ -1225,13 +1225,13 @@ impl PerRealReg {
         fenv: &TypedIxVec<RangeFragIx, RangeFrag>,
         vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
     ) {
-        // Remove it from |vlrixs_assigned|
+        // Remove it from `vlrixs_assigned`
         if self.vlrixs_assigned.contains(to_del_vlrix) {
             self.vlrixs_assigned.delete(to_del_vlrix);
         } else {
             panic!("PerRealReg: del_VirtualRange on VR not in vlrixs_assigned");
         }
-        // Remove it from |committed|
+        // Remove it from `committed`
         let to_del_vlr = &vlr_env[to_del_vlrix];
         self.committedFAST
             .del(&to_del_vlr.sorted_frags, fenv, vlr_env);
@@ -1242,11 +1242,11 @@ impl PerRealReg {
 }
 
 // HELPER FUNCTION
-// In order to allocate |would_like_to_add| for this real reg, we will
-// need to evict |pairs[pairs_ix]|.  That may or may not be possible,
-// given the rules of the game.  If it is possible, update |evict_set| and
-// |evict_cost| accordingly, and return |true|.  If it isn't possible,
-// return |false|; |evict_set| and |evict_cost| must not be changed.
+// In order to allocate `would_like_to_add` for this real reg, we will
+// need to evict `pairs[pairs_ix]`.  That may or may not be possible,
+// given the rules of the game.  If it is possible, update `evict_set` and
+// `evict_cost` accordingly, and return `true`.  If it isn't possible,
+// return `false`; `evict_set` and `evict_cost` must not be changed.
 fn handle_CM_entry(
     evict_set: &mut Set<VirtualRangeIx>,
     evict_cost: &mut SpillCost,
@@ -1270,7 +1270,7 @@ fn handle_CM_entry(
         // RealRange, and hence not evictable.
         return false;
     }
-    // The |unwrap| is guarded by the previous |if|.
+    // The `unwrap` is guarded by the previous `if`.
     let vlrix_to_evict = mb_vlrix_to_evict.unwrap();
     if do_not_evict.contains(vlrix_to_evict) {
         // Our caller asks that we do not evict this one.
@@ -1283,9 +1283,9 @@ fn handle_CM_entry(
     }
     // It's at least plausible.  Check the costs.  Note that because a
     // VirtualRange may contain arbitrarily many RangeFrags, and we're
-    // visiting RangeFrags here, the |evict_set| may well already contain
-    // |vlrix_to_evict|, in the case where we've already visited a different
-    // fragment that "belongs" to |vlrix_to_evict|.  Hence we must be sure
+    // visiting RangeFrags here, the `evict_set` may well already contain
+    // `vlrix_to_evict`, in the case where we've already visited a different
+    // fragment that "belongs" to `vlrix_to_evict`.  Hence we must be sure
     // not to add it again -- if only as as not to mess up the evict cost
     // calculations.
 
@@ -1305,9 +1305,9 @@ fn handle_CM_entry(
 }
 
 // HELPER FUNCTION
-// For a given RangeFrag, traverse the commitment sub-tree rooted at |root|,
-// adding to |running_set| the set of VLRIxs that the frag intersects, and
-// adding their spill costs to |running_cost|.  Return false if, for one of
+// For a given RangeFrag, traverse the commitment sub-tree rooted at `root`,
+// adding to `running_set` the set of VLRIxs that the frag intersects, and
+// adding their spill costs to `running_cost`.  Return false if, for one of
 // the 4 reasons documented below, the traversal has been abandoned, and true
 // if the search completed successfully.
 fn rec_helper(
@@ -1333,7 +1333,7 @@ fn rec_helper(
     // Now figure out:
     // - whether we need to search the left subtree
     // - whether we need to search the right subtree
-    // - whether |pair_frag| overlaps the root of the subtree
+    // - whether `pair_frag` overlaps the root of the subtree
     let go_left = pair_frag.first < root_frag.first;
     let go_right = pair_frag.last > root_frag.last;
     let overlaps_root = pair_frag.last >= root_frag.first && pair_frag.first <= root_frag.last;
@@ -1414,8 +1414,8 @@ fn rec_helper(
         }
     }
 
-    // If we get here, it means that |pair_frag| can be accommodated if we evict
-    // all the frags it overlaps in the entire subtree rooted at |root|.
+    // If we get here, it means that `pair_frag` can be accommodated if we evict
+    // all the frags it overlaps in the entire subtree rooted at `root`.
     // Propagate that (good) news upwards.
     //
     // Stay sane ..
@@ -1426,30 +1426,30 @@ fn rec_helper(
 
 impl PerRealReg {
     // Find the set of VirtualRangeIxs that would need to be evicted in order to
-    // allocate |would_like_to_add| to this register.  Virtual ranges mentioned
-    // in |do_not_evict| must not be considered as candidates for eviction.
+    // allocate `would_like_to_add` to this register.  Virtual ranges mentioned
+    // in `do_not_evict` must not be considered as candidates for eviction.
     // Also returns the total associated spill cost.  That spill cost cannot be
     // infinite.
     //
     // This can fail (return None) for four different reasons:
     //
-    // - |would_like_to_add| interferes with a real-register-live-range
+    // - `would_like_to_add` interferes with a real-register-live-range
     //   commitment, so the register would be unavailable even if we evicted
     //   *all* virtual ranges assigned to it.
     //
-    // - |would_like_to_add| interferes with a virtual range which is a spill
+    // - `would_like_to_add` interferes with a virtual range which is a spill
     //   range (has infinite cost).  We cannot evict those without risking
     //   non-termination of the overall allocation algorithm.
     //
-    // - |would_like_to_add| interferes with a virtual range listed in
-    //   |do_not_evict|.  Our caller uses this mechanism when trying to do
+    // - `would_like_to_add` interferes with a virtual range listed in
+    //   `do_not_evict`.  Our caller uses this mechanism when trying to do
     //   coalesing, to avoid the nonsensicality of evicting some part of a
     //   virtual live range group in order to allocate a member of the same
     //   group.
     //
     // - The total spill cost of the candidate set exceeds the spill cost of
-    //   |would_like_to_add|.  This means that spilling them would be a net loss
-    //   per our cost model.  Note that |would_like_to_add| may have an infinite
+    //   `would_like_to_add`.  This means that spilling them would be a net loss
+    //   per our cost model.  Note that `would_like_to_add` may have an infinite
     //   spill cost, in which case it will "win" over all other
     //   non-infinite-cost eviction candidates.  This is by design (so as to
     //   guarantee that we can always allocate spill/reload bridges).
@@ -1470,17 +1470,17 @@ impl PerRealReg {
         }
 
         // The tree isn't empty, so we will have to do this the hard way: iterate
-        // over all fragments in |would_like_to_add| and check them against the
+        // over all fragments in `would_like_to_add` and check them against the
         // tree.
 
         // Useful constants for the main loop
         let would_like_to_add_vlr = &vlr_env[would_like_to_add];
         let evict_cost_budget = would_like_to_add_vlr.spill_cost;
-        // Note that |evict_cost_budget| can be infinite because
-        // |would_like_to_add| might be a spill/reload range.
+        // Note that `evict_cost_budget` can be infinite because
+        // `would_like_to_add` might be a spill/reload range.
 
         // The overall evict set and cost so far.  These are updated as we iterate
-        // over the fragments that make up |would_like_to_add|.
+        // over the fragments that make up `would_like_to_add`.
         let mut running_set = Set::<VirtualRangeIx>::empty();
         let mut running_cost = SpillCost::zero();
 
@@ -1505,7 +1505,7 @@ impl PerRealReg {
             // And move on to the next fragment.
         }
 
-        // If we got here, it means that |would_like_to_add| can be accommodated \o/
+        // If we got here, it means that `would_like_to_add` can be accommodated \o/
         assert!(running_cost.is_finite());
         assert!(running_cost.is_less_than(&evict_cost_budget));
         Some((running_set, running_cost))
@@ -1525,8 +1525,8 @@ impl PerRealReg {
         // Useful constants for the loop
         let would_like_to_add_vlr = &vlr_env[would_like_to_add];
         let evict_cost_budget = would_like_to_add_vlr.spill_cost;
-        // Note that |evict_cost_budget| can be infinite because
-        // |would_like_to_add| might be a spill/reload range.
+        // Note that `evict_cost_budget` can be infinite because
+        // `would_like_to_add` might be a spill/reload range.
 
         let vr_ip_first = frag_env[would_like_to_add_vlr.sorted_frags.frag_ixs[0]].first;
         let vr_ip_last = frag_env[would_like_to_add_vlr.sorted_frags.frag_ixs
@@ -1553,7 +1553,7 @@ impl PerRealReg {
                     break;
                 }
 
-                // Find out any vr entry contains |vr_ip|, if any.  If not, move on.
+                // Find out any vr entry contains `vr_ip`, if any.  If not, move on.
                 let mut found_in_vr = false;
                 for fix in &would_like_to_add_vlr.sorted_frags.frag_ixs {
                     let frag = &frag_env[*fix];
@@ -1564,10 +1564,10 @@ impl PerRealReg {
                 }
                 if !found_in_vr {
                     vr_ip = vr_ip.step();
-                    continue; // there can't be any intersection at |vr_ip|
+                    continue; // there can't be any intersection at `vr_ip`
                 }
 
-                // Find the cm entry containing |vr_ip|
+                // Find the cm entry containing `vr_ip`
                 let mut pair_ix = 0;
                 let mut found = false;
                 for pair in &self.committed.pairs {
@@ -1704,8 +1704,8 @@ fn print_RA_state(
 //=============================================================================
 // Frag compression
 
-// Does |frag1| describe some range of instructions that is followed
-// immediately by |frag2| ?  Note that this assumes (and checks) that there
+// Does `frag1` describe some range of instructions that is followed
+// immediately by `frag2` ?  Note that this assumes (and checks) that there
 // are no spill or reload ranges in play at this point; there should not be.
 fn frags_are_mergeable(frag1: &RangeFrag, frag2: &RangeFrag) -> bool {
     assert!(frag1.first.pt.is_use_or_def());
@@ -1738,9 +1738,9 @@ fn frags_are_mergeable(frag1: &RangeFrag, frag2: &RangeFrag) -> bool {
 const Z_INVALID_BLOCKIX: BlockIx = BlockIx::BlockIx(0xFFFF_FFFF);
 const Z_INVALID_COUNT: u16 = 0xFFFF;
 
-// Try and compress the fragments for each virtual range in |vlr_env|, adding
-// new ones to |frag_env| as we go.  Note this is a big kludge, in the sense
-// that the new |RangeFrags| have bogus |bix|, |kind| and |count| fields, and
+// Try and compress the fragments for each virtual range in `vlr_env`, adding
+// new ones to `frag_env` as we go.  Note this is a big kludge, in the sense
+// that the new `RangeFrags` have bogus `bix`, `kind` and `count` fields, and
 // we rely on the fact that the backtracking core algorithm won't look at them
 // after this point.  This should be fixed cleanly.
 #[inline(never)]
@@ -2001,10 +2001,10 @@ pub fn alloc_main<F: Function>(
         );
     }
 
-    // This is also part of the running state.  |vlr_slot_env| tells us the
+    // This is also part of the running state.  `vlr_slot_env` tells us the
     // assigned spill slot for each VirtualRange, if any.
-    // |spill_slot_allocator| decides on the assignments and writes them into
-    // |vlr_slot_env|.
+    // `spill_slot_allocator` decides on the assignments and writes them into
+    // `vlr_slot_env`.
     let mut vlr_slot_env = TypedIxVec::<VirtualRangeIx, Option<SpillSlot>>::new();
     vlr_slot_env.resize(num_vlrs_initial, None);
     let mut spill_slot_allocator = SpillSlotAllocator::new();
@@ -2071,20 +2071,20 @@ pub fn alloc_main<F: Function>(
 
         // ====== BEGIN Try to do coalescing ======
         //
-        // First, look through the hints for |curr_vlr|, collecting up candidate
-        // real regs, in decreasing order of preference, in |hinted_regs|.  Note
+        // First, look through the hints for `curr_vlr`, collecting up candidate
+        // real regs, in decreasing order of preference, in `hinted_regs`.  Note
         // that we don't have to consider the weights here, because the coalescing
         // analysis phase has already sorted the hints for the VLR so as to
         // present the most favoured (weighty) first, so we merely need to retain
-        // that ordering when copying into |hinted_regs|.
+        // that ordering when copying into `hinted_regs`.
         // FIXME (very) SmallVec
         let mut hinted_regs = Vec::<RealReg>::new();
         let mut mb_curr_vlr_eclass: Option<Set<VirtualRangeIx>> = None;
 
-        // === BEGIN collect all hints for |curr_vlr| ===
-        // |hints| has one entry per VLR, but only for VLRs which existed
+        // === BEGIN collect all hints for `curr_vlr` ===
+        // `hints` has one entry per VLR, but only for VLRs which existed
         // initially (viz, not for any created by spilling/splitting/whatever).
-        // Similarly, |vlrEquivClasses| can only map VLRs that existed initially,
+        // Similarly, `vlrEquivClasses` can only map VLRs that existed initially,
         // and will panic otherwise.  Hence the following check:
         if curr_vlrix.get() < hints.len() {
             for hint in &hints[curr_vlrix] {
@@ -2093,12 +2093,12 @@ pub fn alloc_main<F: Function>(
                     Hint::SameAs(other_vlrix, _weight) => {
                         // It wants the same reg as some other VLR, but we can only honour
                         // that if the other VLR actually *has* a reg at this point.  Its
-                        // |rreg| field will tell us exactly that.
+                        // `rreg` field will tell us exactly that.
                         vlr_env[*other_vlrix].rreg
                     }
                     Hint::Exactly(rreg, _weight) => Some(*rreg),
                 };
-                // So now |mb_cand| might have a preferred real reg.  If so, add it to
+                // So now `mb_cand` might have a preferred real reg.  If so, add it to
                 // the list of cands.  De-dup as we go, since that is way cheaper than
                 // effectively doing the same via repeated lookups in the
                 // CommitmentMaps.
@@ -2110,18 +2110,18 @@ pub fn alloc_main<F: Function>(
                 // END for each hint
             }
 
-            // At this point, we have in |hinted_regs|, the hint candidates that
-            // arise from copies between |curr_vlr| and its immediate neighbouring
+            // At this point, we have in `hinted_regs`, the hint candidates that
+            // arise from copies between `curr_vlr` and its immediate neighbouring
             // VLRs or RLRs, in order of declining preference.  And that is a good
             // start.  However, it may be the case that there is some other VLR
-            // which is in the same equivalence class as |curr_vlr|, but is not a
+            // which is in the same equivalence class as `curr_vlr`, but is not a
             // direct neighbour, and which has already been assigned a register.  We
             // really ought to take those into account too, as the least-preferred
             // candidates.  Hence we need to iterate over the equivalence class and
             // "round up the secondary candidates."
             let n_primary_cands = hinted_regs.len();
 
-            // Find the equivalence class set for |curr_vlrix|.  We'll need it
+            // Find the equivalence class set for `curr_vlrix`.  We'll need it
             // later.
             let mut curr_vlr_eclass = Set::<VirtualRangeIx>::empty();
             for vlrix in vlrEquivClasses.equiv_class_elems_iter(curr_vlrix) {
@@ -2134,7 +2134,7 @@ pub fn alloc_main<F: Function>(
             for vlrix in vlrEquivClasses.equiv_class_elems_iter(curr_vlrix) {
                 if vlrix != curr_vlrix {
                     if let Some(rreg) = vlr_env[vlrix].rreg {
-                        // Add |rreg| as a cand, if we don't already have it.
+                        // Add `rreg` as a cand, if we don't already have it.
                         if !hinted_regs.iter().any(|r| *r == rreg) {
                             hinted_regs.push(rreg);
                         }
@@ -2163,9 +2163,9 @@ pub fn alloc_main<F: Function>(
                 }
             }
         }
-        // === END collect all hints for |curr_vlr| ===
+        // === END collect all hints for `curr_vlr` ===
 
-        // === BEGIN try to use the hints for |curr_vlr| ===
+        // === BEGIN try to use the hints for `curr_vlr` ===
         // Now work through the list of preferences, to see if we can honour any
         // of them.
         for rreg in &hinted_regs {
@@ -2179,8 +2179,8 @@ pub fn alloc_main<F: Function>(
             // live range, which we can't do.
             //
             // We take care not to evict any range which is in the same equivalence
-            // class as |curr_vlr| since those are (by definition) connected to
-            // |curr_vlr| via V-V copies, and so evicting any of them would be
+            // class as `curr_vlr` since those are (by definition) connected to
+            // `curr_vlr` via V-V copies, and so evicting any of them would be
             // counterproductive from the point of view of removing copies.
 
             let do_not_evict = if let Some(ref curr_vlr_eclass) = mb_curr_vlr_eclass {
@@ -2206,7 +2206,7 @@ pub fn alloc_main<F: Function>(
                 assert!(total_evict_cost.is_less_than(&curr_vlr.spill_cost));
                 // Evict all evictees in the set
                 for vlrix_to_evict in vlrixs_to_evict.iter() {
-                    // Ensure we're not evicting anything in |curr_vlrix|'s eclass.
+                    // Ensure we're not evicting anything in `curr_vlrix`'s eclass.
                     // This should be guaranteed us by find_Evict_Set.
                     assert!(!do_not_evict.contains(*vlrix_to_evict));
                     // Evict ..
@@ -2231,7 +2231,7 @@ pub fn alloc_main<F: Function>(
                 continue 'main_allocation_loop;
             }
         } /* for rreg in hinted_regs */
-        // === END try to use the hints for |curr_vlr| ===
+        // === END try to use the hints for `curr_vlr` ===
 
         // ====== END Try to do coalescing ======
 
@@ -2381,7 +2381,7 @@ pub fn alloc_main<F: Function>(
               }
         */
 
-        // We will be spilling vreg |curr_vlr.reg| with VirtualRange |curr_vlr| to
+        // We will be spilling vreg `curr_vlr.reg` with VirtualRange `curr_vlr` to
         // a spill slot that the spill slot allocator will choose for us, just a
         // bit further down this function.
 
@@ -2389,7 +2389,7 @@ pub fn alloc_main<F: Function>(
         // instructions around an instruction that references a VirtualReg
         // that has been spilled.
         struct SpillAndOrReloadInfo {
-            bix: BlockIx,     // that |iix| is in
+            bix: BlockIx,     // that `iix` is in
             iix: InstIx,      // this is the Inst we are spilling/reloading for
             kind: BridgeKind, // says whether to create a spill or reload or both
         }
@@ -2452,7 +2452,7 @@ pub fn alloc_main<F: Function>(
             }
         }
 
-        // Now that we no longer need to access |frag_env| or |vlr_env| for
+        // Now that we no longer need to access `frag_env` or `vlr_env` for
         // the remainder of this iteration of the main allocation loop, we can
         // actually generate the required spill/reload artefacts.
 
@@ -2465,7 +2465,7 @@ pub fn alloc_main<F: Function>(
         assert!(curr_vlrix < VirtualRangeIx::new(num_vlrs_initial));
         if vlr_slot_env[curr_vlrix].is_none() {
             // It hasn't been decided yet.  Cause it to be so by asking for an
-            // allocation for the entire eclass that |curr_vlrix| belongs to.
+            // allocation for the entire eclass that `curr_vlrix` belongs to.
             spill_slot_allocator.alloc_spill_slots(
                 &mut vlr_slot_env,
                 func,
@@ -2559,11 +2559,11 @@ pub fn alloc_main<F: Function>(
     debug!("");
     info!("alloc_main:   create spills_n_reloads for MOVE insns");
 
-    // Sort |edit_list_move| by the insn with which each item is associated.
+    // Sort `edit_list_move` by the insn with which each item is associated.
     edit_list_move.sort_unstable_by(|eli1, eli2| eli1.iix.cmp(&eli2.iix));
 
-    // Now go through |edit_list_move| and find pairs which constitute a
-    // spillslot-to-the-same-spillslot move.  What we have in |edit_list_move| is
+    // Now go through `edit_list_move` and find pairs which constitute a
+    // spillslot-to-the-same-spillslot move.  What we have in `edit_list_move` is
     // heavily constrained, as follows:
     //
     // * each entry should reference an InstIx which the coalescing analysis
@@ -2581,7 +2581,7 @@ pub fn alloc_main<F: Function>(
     // * For a referenced instruction, there may be at most two entries in this
     //   list: one that references the R->U frag and one that references the
     //   D->S frag.  Furthermore, the two entries must carry values of the same
-    //   RegClass; if that isn't true, the client's |is_move| function is
+    //   RegClass; if that isn't true, the client's `is_move` function is
     //   defective.
     //
     // For any such pair identified, if both frags mention the same spill slot,
@@ -2589,9 +2589,9 @@ pub fn alloc_main<F: Function>(
     // note that the instruction itself is to be deleted (converted to a
     // zero-len nop).  In a sense we have "cancelled out" a reload/spill pair.
     // Entries that can't be cancelled out are handled the same way as for
-    // entries in |edit_list_other|, by simply copying them there.
+    // entries in `edit_list_other`, by simply copying them there.
     //
-    // Since |edit_list_move| is sorted by insn ix, we can scan linearly over
+    // Since `edit_list_move` is sorted by insn ix, we can scan linearly over
     // it, looking for adjacent pairs.  We'll have to accept them in either
     // order though (first R->U then D->S, or the other way round).  There's no
     // fixed ordering since there is no particular ordering in the way
@@ -2600,9 +2600,9 @@ pub fn alloc_main<F: Function>(
     // As a result of spill slot coalescing, we'll need to delete the move
     // instructions leading to a mergable spill slot move.  The insn stream
     // editor can't delete instructions, so instead it'll replace them with zero
-    // len nops obtained from the client.  |iixs_to_nop_out| records the insns
+    // len nops obtained from the client.  `iixs_to_nop_out` records the insns
     // that this has to happen to.  It is in increasing order of InstIx (because
-    // |edit_list_sorted| is), and the indices in it refer to the original
+    // `edit_list_sorted` is), and the indices in it refer to the original
     // virtual-registerised code.
     let mut iixs_to_nop_out = Vec::<InstIx>::new();
 
@@ -2665,7 +2665,7 @@ pub fn alloc_main<F: Function>(
             }
         }
         // If we get here for whatever reason, this group is uninteresting.  Copy
-        // in to |edit_list_other| so that it gets processed in the normal way.
+        // in to `edit_list_other` so that it gets processed in the normal way.
         for i in i_min..=i_max {
             edit_list_other.push(edit_list_move[i]);
             n_edit_list_move_processed += 1;
@@ -2768,8 +2768,8 @@ pub fn alloc_main<F: Function>(
             let VirtualRange {
                 vreg, sorted_frags, ..
             } = &vlr_env[*vlrix_assigned];
-            // All the RangeFrags in |vlr_assigned| require |vlr_assigned.reg|
-            // to be mapped to the real reg |i|
+            // All the RangeFrags in `vlr_assigned` require `vlr_assigned.reg`
+            // to be mapped to the real reg `i`
             // .. collect up all its constituent RangeFrags.
             for fix in &sorted_frags.frag_ixs {
                 frag_map.push((*fix, *vreg, rreg));
@@ -2837,10 +2837,10 @@ pub fn alloc_main<F: Function>(
     // FIXME: derive this information directly from the allocation data
     // structures used above.
     //
-    // NB at this point, the |san_reg_uses| that was computed in the analysis
+    // NB at this point, the `san_reg_uses` that was computed in the analysis
     // phase is no longer valid, because we've added and removed instructions to
-    // the function relative to the one that |san_reg_uses| was computed from,
-    // so we have to re-visit all insns with |add_raw_reg_vecs_for_insn|.
+    // the function relative to the one that `san_reg_uses` was computed from,
+    // so we have to re-visit all insns with `add_raw_reg_vecs_for_insn`.
     // That's inefficient, but we don't care .. this should only be a temporary
     // fix.
 

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -237,8 +237,8 @@ impl<'a, T> Iterator for SetIter<'a, T> {
 //   for ent in startEnt .dotdot( endPlus1Ent ) {
 //   }
 //
-// until such time as |trait Step| is available in stable Rust.  At that point
-// |fn dotdot| and all of the following can be removed, and the loops
+// until such time as `trait Step` is available in stable Rust.  At that point
+// `fn dotdot` and all of the following can be removed, and the loops
 // rewritten using the standard syntax:
 //
 //   for ent in startEnt .. endPlus1Ent {
@@ -588,13 +588,13 @@ impl RegClass {
 // Virtual Reg:   1  rc:3                index:28
 // Real Reg:      0  rc:3  uu:12  enc:8  index:8
 //
-// |rc| is the register class.  |uu| means "unused".  |enc| is the hardware
-// encoding for the reg.  |index| is a zero based index which has the
+// `rc` is the register class.  `uu` means "unused".  `enc` is the hardware
+// encoding for the reg.  `index` is a zero based index which has the
 // following meanings:
 //
-// * for a Virtual Reg, |index| is just the virtual register number.
-// * for a Real Reg, |index| is the entry number in the associated
-//   |RealRegUniverse|.
+// * for a Virtual Reg, `index` is just the virtual register number.
+// * for a Real Reg, `index` is the entry number in the associated
+//   `RealRegUniverse`.
 //
 // This scheme gives us:
 //
@@ -874,7 +874,7 @@ impl fmt::Debug for SpillSlot {
 // Register uses: low level interface
 
 // This minimal struct is visible from outside the regalloc.rs interface.  It
-// is intended to be a safe wrapper around |RegVecs|, which isn't externally
+// is intended to be a safe wrapper around `RegVecs`, which isn't externally
 // visible.  It is used to collect unsanitized reg use info from client
 // instructions.
 pub struct RegUsageCollector<'a> {
@@ -924,8 +924,8 @@ impl<'a> RegUsageCollector<'a> {
 
 // Everything else is not visible outside the regalloc.rs interface.
 
-// There is one of these per function.  Note that |defs| and |mods| lose the
-// |Writable| constraint at this point.  This is for convenience of having all
+// There is one of these per function.  Note that `defs` and `mods` lose the
+// `Writable` constraint at this point.  This is for convenience of having all
 // three vectors be the same type, but comes at the cost of the loss of being
 // able to differentiate readonly vs read/write registers in the Rust type
 // system.
@@ -992,7 +992,7 @@ pub struct RegVecsAndBounds {
     // The three vectors of registers.  These can be arbitrarily long.
     pub vecs: RegVecs,
     // Admin info which tells us the location, for each insn, of its register
-    // groups in |vecs|.
+    // groups in `vecs`.
     pub bounds: TypedIxVec<InstIx, RegVecBounds>,
 }
 impl RegVecsAndBounds {
@@ -1012,7 +1012,7 @@ impl RegVecsAndBounds {
 
 // Some call sites want to get reg use information as three Sets.  This is a
 // "convenience facility" which is easier to use but much slower than working
-// with a whole-function |RegVecsAndBounds|.  It shouldn't be used on critical
+// with a whole-function `RegVecsAndBounds`.  It shouldn't be used on critical
 // paths.
 #[derive(Debug)]
 pub struct RegSets {
@@ -1081,15 +1081,15 @@ pub struct RealRegUniverse {
     // registers.
     pub regs: Vec<(RealReg, String)>,
 
-    // This is the size of the initial section of |regs| that is available to
-    // the allocator.  It must be < |regs|.len().
+    // This is the size of the initial section of `regs` that is available to
+    // the allocator.  It must be < `regs`.len().
     pub allocable: usize,
 
     // Information about groups of allocable registers. Used to quickly address
     // only a group of allocable registers belonging to the same register class.
-    // Indexes into |allocable_by_class| are RegClass values, such as
-    // RegClass::F32. If the resulting entry is |None| then there are no
-    // registers in that class.  Otherwise the value is a |RegClassInfo|, which
+    // Indexes into `allocable_by_class` are RegClass values, such as
+    // RegClass::F32. If the resulting entry is `None` then there are no
+    // registers in that class.  Otherwise the value is a `RegClassInfo`, which
     // provides a register range and possibly information about fixed uses.
     pub allocable_by_class: [Option<RegClassInfo>; NUM_REG_CLASSES],
 }
@@ -1101,12 +1101,12 @@ pub struct RegClassInfo {
     // register indices.
     //
     // A range (first, last) specifies the range of entries in
-    // |RealRegUniverse.regs| corresponding to that class.  The range includes
-    // both |first| and |last|.
+    // `RealRegUniverse.regs` corresponding to that class.  The range includes
+    // both `first` and `last`.
     //
-    // In all cases, |last| must be < |RealRegUniverse.allocable|.  In other
-    // words, all ranges together in |allocable_by_class| must describe only the
-    // allocable prefix of |regs|.
+    // In all cases, `last` must be < `RealRegUniverse.allocable`.  In other
+    // words, all ranges together in `allocable_by_class` must describe only the
+    // allocable prefix of `regs`.
     //
     // For example, let's say
     //    allocable_by_class[RegClass::F32] ==
@@ -1114,7 +1114,7 @@ pub struct RegClassInfo {
     // Then regs[10], regs[11], regs[12], regs[13], and regs[14] give all
     // registers of register class RegClass::F32.
     //
-    // The effect of the above is that registers in |regs| must form
+    // The effect of the above is that registers in `regs` must form
     // contiguous groups. This is checked by RealRegUniverse::check_is_sane().
     pub first: usize,
     pub last: usize,
@@ -1134,21 +1134,21 @@ impl RealRegUniverse {
         let regs_len = self.regs.len();
         let regs_allocable = self.allocable;
         // The universe must contain at most 256 registers.  That's because
-        // |Reg| only has an 8-bit index value field, so if the universe
+        // `Reg` only has an 8-bit index value field, so if the universe
         // contained more than 256 registers, we'd never be able to index into
         // entries 256 and above.  This is no limitation in practice since all
         // targets we're interested in contain (many) fewer than 256 regs in
         // total.
         let mut ok = regs_len <= 256;
         // The number of allocable registers must not exceed the number of
-        // |regs| presented.  In general it will be less, since the universe
+        // `regs` presented.  In general it will be less, since the universe
         // will list some registers (stack pointer, etc) which are not
         // available for allocation.
         if ok {
             ok = regs_allocable <= regs_len;
         }
         // All registers must have an index value which points back at the
-        // |regs| slot they are in.  Also they really must be real regs.
+        // `regs` slot they are in.  Also they really must be real regs.
         if ok {
             for i in 0..regs_len {
                 let (reg, _name) = &self.regs[i];
@@ -1157,8 +1157,8 @@ impl RealRegUniverse {
                 }
             }
         }
-        // The allocatable regclass groupings defined by |allocable_first| and
-        // |allocable_last| must be contiguous.
+        // The allocatable regclass groupings defined by `allocable_first` and
+        // `allocable_last` must be contiguous.
         if ok {
             let mut regclass_used = [false; NUM_REG_CLASSES];
             for rc in 0..NUM_REG_CLASSES {
@@ -1307,7 +1307,7 @@ impl PartialOrd for Point {
     }
 }
 
-// See comments below on |RangeFrag| for the meaning of |InstPoint|.
+// See comments below on `RangeFrag` for the meaning of `InstPoint`.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Ord)]
 pub struct InstPoint {
     pub iix: InstIx,
@@ -1357,7 +1357,7 @@ impl InstPoint {
 }
 impl PartialOrd for InstPoint {
     // Again .. don't assume anything about the #derive'd version.  These have
-    // to be ordered using |iix| as the primary key and |pt| as the
+    // to be ordered using `iix` as the primary key and `pt` as the
     // secondary.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.iix.partial_cmp(&other.iix) {
@@ -1459,7 +1459,7 @@ impl fmt::Debug for RangeFragKind {
 // different "points" within each instruction: the Use position, where
 // incoming registers are read, and the Def position, where outgoing registers
 // are written.  The Use position is considered to come before the Def
-// position, as described for |Point| above.
+// position, as described for `Point` above.
 //
 // When we come to generate spill/restore live ranges, Point::S and Point::R
 // also come into play.  Live ranges (and hence, RangeFrags) that do not perform
@@ -1475,14 +1475,14 @@ impl fmt::Debug for RangeFragKind {
 // block: the insn number is used as the primary key, and the Point part is
 // the secondary key, with Reload < Use < Def < Spill.
 //
-// Finally, a RangeFrag has a |count| field, which is a u16 indicating how often
+// Finally, a RangeFrag has a `count` field, which is a u16 indicating how often
 // the associated storage unit (Reg) is mentioned inside the RangeFrag.  It is
-// assumed that the RangeFrag is associated with some Reg.  If not, the |count|
+// assumed that the RangeFrag is associated with some Reg.  If not, the `count`
 // field is meaningless.
 //
-// The |bix| field is actually redundant, since the containing |Block| can be
-// inferred, laboriously, from |first| and |last|, providing you have a
-// |Block| table to hand.  It is included here for convenience.
+// The `bix` field is actually redundant, since the containing `Block` can be
+// inferred, laboriously, from `first` and `last`, providing you have a
+// `Block` table to hand.  It is included here for convenience.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RangeFrag {
     pub bix: BlockIx,
@@ -1673,7 +1673,7 @@ impl SpillCost {
         SpillCost::Infinite
     }
     pub fn finite(cost: f32) -> Self {
-        // "|is_normal| returns true if the number is neither zero, infinite,
+        // "`is_normal` returns true if the number is neither zero, infinite,
         // subnormal, or NaN."
         assert!(cost.is_normal() || cost == 0.0);
         // And also it can't be negative.
@@ -1711,7 +1711,7 @@ impl SpillCost {
     }
     pub fn partial_cmp_debug_only(&self, other: &Self) -> Option<Ordering> {
         // NB!  This is only for debugging; it serves only to give an arbitrary
-        // structural partial ordering on |SpillCost| so it can participate in
+        // structural partial ordering on `SpillCost` so it can participate in
         // sorting.  The induced ordering should not be used to make any
         // judgements about spill costs.
         match (self, other) {
@@ -1750,12 +1750,12 @@ impl SpillCost {
 //
 // VirtualRanges contain metrics.  Not all are initially filled in:
 //
-// * |size| is the number of instructions in total spanned by the LR.  It must
+// * `size` is the number of instructions in total spanned by the LR.  It must
 //   not be zero.
 //
-// * |spill_cost| is an abstractified measure of the cost of spilling the LR.
-//   The only constraint (w.r.t. correctness) is that normal LRs have a |Some|
-//   value, whilst |None| is reserved for live ranges created for spills and
+// * `spill_cost` is an abstractified measure of the cost of spilling the LR.
+//   The only constraint (w.r.t. correctness) is that normal LRs have a `Some`
+//   value, whilst `None` is reserved for live ranges created for spills and
 //   reloads and interpreted to mean "infinity".  This is needed to guarantee
 //   that allocation can always succeed in the worst case, in which all of the
 //   original live ranges of the program are spilled.
@@ -1765,16 +1765,16 @@ impl SpillCost {
 //
 // I find it helpful to think of a live range, both RealRange and
 // VirtualRange, as a "renaming equivalence class".  That is, if you rename
-// |reg| at some point inside |sorted_frags|, then you must rename *all*
-// occurrences of |reg| inside |sorted_frags|, since otherwise the program will
+// `reg` at some point inside `sorted_frags`, then you must rename *all*
+// occurrences of `reg` inside `sorted_frags`, since otherwise the program will
 // no longer work.
 //
-// Invariants for RealRange/VirtualRange RangeFrag sets (their |sfrags| fields):
+// Invariants for RealRange/VirtualRange RangeFrag sets (their `sfrags` fields):
 //
-// * Either |sorted_frags| contains just one RangeFrag, in which case it *must*
+// * Either `sorted_frags` contains just one RangeFrag, in which case it *must*
 //   be RangeFragKind::Local.
 //
-// * Or |sorted_frags| contains more than one RangeFrag, in which case: at
+// * Or `sorted_frags` contains more than one RangeFrag, in which case: at
 //   least one must be RangeFragKind::LiveOut, at least one must be
 //   RangeFragKind::LiveIn, and there may be zero or more RangeFragKind::Thrus.
 

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -176,7 +176,7 @@ fn map_vregs_to_rregs<F: Function>(
             return true;
         }
         // A spill-related ("bridge") frag.  There are three possibilities,
-        // and they correspond exactly to |BridgeKind|.
+        // and they correspond exactly to `BridgeKind`.
         if frag.first.pt.is_reload() && frag.last.pt.is_use() && frag.last.iix == frag.first.iix {
             // BridgeKind::RtoU
             return true;
@@ -428,7 +428,7 @@ fn map_vregs_to_rregs<F: Function>(
 }
 
 //=============================================================================
-// Take the real-register-only code created by |map_vregs_to_rregs| and
+// Take the real-register-only code created by `map_vregs_to_rregs` and
 // interleave extra instructions (spills, reloads and moves) that the core
 // algorithm has asked us to add.
 
@@ -446,14 +446,14 @@ fn add_spills_reloads_and_moves<F: Function>(
 
     insts_to_add.sort_by_key(|mem_move| mem_move.point);
 
-    let mut curITA = 0; // cursor in |insts_to_add|
+    let mut curITA = 0; // cursor in `insts_to_add`
     let mut curB = BlockIx::new(0); // cursor in Func::blocks
 
     let mut insns: Vec<F::Inst> = vec![];
     let mut target_map: TypedIxVec<BlockIx, InstIx> = TypedIxVec::new();
 
     for iix in func.insn_indices() {
-        // Is |iix| the first instruction in a block?  Meaning, are we
+        // Is `iix` the first instruction in a block?  Meaning, are we
         // starting a new block?
         debug_assert!(curB.get() < func.blocks().len() as u32);
         if func.block_insns(curB).start() == iix {
@@ -462,24 +462,24 @@ fn add_spills_reloads_and_moves<F: Function>(
         }
 
         // Copy to the output vector, the extra insts that are to be placed at the
-        // reload point of |iix|.
+        // reload point of `iix`.
         while curITA < insts_to_add.len()
             && insts_to_add[curITA].point == InstPoint::new_reload(iix)
         {
             insns.push(insts_to_add[curITA].inst.construct(func));
             curITA += 1;
         }
-        // Copy the inst at |iix| itself
+        // Copy the inst at `iix` itself
         insns.push(func.get_insn(iix).clone());
         // And copy the extra insts that are to be placed at the spill point of
-        // |iix|.
+        // `iix`.
         while curITA < insts_to_add.len() && insts_to_add[curITA].point == InstPoint::new_spill(iix)
         {
             insns.push(insts_to_add[curITA].inst.construct(func));
             curITA += 1;
         }
 
-        // Is |iix| the last instruction in a block?
+        // Is `iix` the last instruction in a block?
         if iix == func.block_insns(curB).last() {
             debug_assert!(curB.get() < func.blocks().len() as u32);
             curB = curB.plus(1);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -100,7 +100,7 @@ pub use crate::data_structures::SpillSlot;
 //
 // This is of course inconvenient for the caller, since it requires
 // maintenance of two separate universes.  In the future we will add a boolean
-// parameter to the top level function |allocate_registers| that indicates
+// parameter to the top level function `allocate_registers` that indicates
 // that whether or not the function is a leaf function.
 //
 // === (3) === The "suggested scratch register" ===
@@ -120,12 +120,12 @@ pub use crate::data_structures::SpillSlot;
 //
 // (3) The reserved register must not have any reads or modifies by any
 //     instruction in the vcode.  In other words, it must not be handed to
-//     either the |add_use| or |add_mod| function of the |RegUsageCollector|
-//     that is presented to the client's |get_regs| function.  If any such
+//     either the `add_use` or `add_mod` function of the `RegUsageCollector`
+//     that is presented to the client's `get_regs` function.  If any such
 //     mention is detected, the library will return an error.
 //
 // (4) The reserved reg may be mentioned as written by instructions in the
-//     vcode, though -- in other words it may be handed to |add_def|.  The
+//     vcode, though -- in other words it may be handed to `add_def`.  The
 //     library will tolerate and correctly handle that.  However, because no
 //     vcode instruction may read or modify the reserved register, all such
 //     writes are "dead".  This in turn guarantees that the allocator can, if
@@ -198,7 +198,7 @@ pub trait Function {
     // Instruction register slots
     // --------------------------
 
-    /// Add to |collector| the used, defined, and modified registers for an
+    /// Add to `collector` the used, defined, and modified registers for an
     /// instruction.
     fn get_regs(insn: &Self::Inst, collector: &mut RegUsageCollector);
 
@@ -328,7 +328,7 @@ pub struct RegAllocResult<F: Function> {
     pub num_spill_slots: u32,
 
     /// Block annotation strings, for debugging.  Requires requesting in the
-    /// call to |allocate_registers|.  Creating of these annotations is
+    /// call to `allocate_registers`.  Creating of these annotations is
     /// potentially expensive, so don't request them if you don't need them.
     pub block_annotations: Option<TypedIxVec<BlockIx, Vec<String>>>,
 }

--- a/lib/src/linear_scan.rs
+++ b/lib/src/linear_scan.rs
@@ -2244,7 +2244,7 @@ fn cmp_interval_tree(
     (left, left_id).partial_cmp(&(right, right_id))
 }
 
-// Allocator top level.  |func| is modified so that, when this function
+// Allocator top level.  `func` is modified so that, when this function
 // returns, it will contain no VirtualReg uses.  Allocation can fail if there
 // are insufficient registers to even generate spill/reload code, or if the
 // function appears to have any undefined VirtualReg/RealReg uses.
@@ -3265,10 +3265,10 @@ fn apply_registers<F: Function>(
     // FIXME: derive this information directly from the allocation data
     // structures used above.
     //
-    // NB at this point, the |san_reg_uses| that was computed in the analysis
+    // NB at this point, the `san_reg_uses` that was computed in the analysis
     // phase is no longer valid, because we've added and removed instructions to
-    // the function relative to the one that |san_reg_uses| was computed from,
-    // so we have to re-visit all insns with |add_raw_reg_vecs_for_insn|.
+    // the function relative to the one that `san_reg_uses` was computed from,
+    // so we have to re-visit all insns with `add_raw_reg_vecs_for_insn`.
     // That's inefficient, but we don't care .. this should only be a temporary
     // fix.
 


### PR DESCRIPTION
This was done using the following sed line:

    sed -r "s%^([^\|]*//[^\|]*)\|(.*)\|(.*)%\1\`\2\`\3%"

applied repeatitively until it reaches a fixed point, on each rust file.