### PR TITLE
Formatting followups

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+# This file tells tools we use rustfmt. We use the default settings.

--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 mod fuzzing;
 mod parser;
 mod test_cases;

--- a/bin/test_cases.rs
+++ b/bin/test_cases.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 /// Test cases.  The list of them is right at the bottom, function `find_Func`.
 /// Add new ones there.
 use regalloc::{Reg, RegClass};

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 //! As part of this set of test cases, we define a mini IR and implement the
 //! `Function` trait for it so that we can use the regalloc public interface.
 

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -20,60 +20,71 @@ static mut COUNTER_GEN: usize = 0;
 static mut COUNTER_OK: usize = 0;
 
 fuzz_target!(|func: ir::Func| {
-  let n_gen = unsafe { COUNTER_GEN += 1; COUNTER_GEN };
-  let n_ok = unsafe { COUNTER_OK };
-  println!("==== BEGIN fuzz_bt.rs: #gen'd {:?} #ok {} ========================",
-           n_gen, n_ok);
+    let n_gen = unsafe {
+        COUNTER_GEN += 1;
+        COUNTER_GEN
+    };
+    let n_ok = unsafe { COUNTER_OK };
+    println!(
+        "==== BEGIN fuzz_bt.rs: #gen'd {:?} #ok {} ========================",
+        n_gen, n_ok
+    );
 
-  if false {
-    println!("BEGIN INPUT:");
-    let mut rendered = String::new();
-    func.render("==== fuzz_bt.rs: failing input:", &mut rendered).unwrap();
-    println!("{}", rendered);
-    println!("END INPUT:");
-  }
-
-  let mut func = func;
-
-  let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize;
-  let reg_universe = ir::make_universe(num_regs, num_regs);
-
-  let func_backup = func.clone();
-
-  let ra_result = regalloc::allocate_registers(
-    &mut func,
-    //TODO reenable checking once #47 is fixed.
-    regalloc::RegAllocAlgorithm::Backtracking,
-    &reg_universe,
-    /*request_block_annotations=*/false
-  );
-
-  match ra_result {
-    Ok(result) => {
-      func.update_from_alloc(result);
-      unsafe { COUNTER_OK += 1; }
-      return;
-    }
-    Err(err) => {
-      let mut stop = false;
-      if let regalloc::RegAllocError::RegChecker(_) = &err {
-        stop = true;
-        println!("==== fuzz_bt.rs: checker error: {:?}", err);
-      }
-      if stop {
+    if false {
+        println!("BEGIN INPUT:");
         let mut rendered = String::new();
-        func_backup.render("==== fuzz_bt.rs: failing input:",
-                           &mut rendered).unwrap();
+        func.render("==== fuzz_bt.rs: failing input:", &mut rendered)
+            .unwrap();
         println!("{}", rendered);
-      }
-      println!("==== fuzz_bt.rs: failure reason: {}", err);
-      if stop {
-        println!("==== fuzz_bt.rs:");
-        println!("==== fuzz_bt.rs: to repro, use flags '-f {} -i {}'",
-                num_regs, num_regs);
-        println!("==== fuzz_bt.rs:");
-        panic!("==== fuzz_bt.rs: STOPPING.  Bye! ====");
-      }
+        println!("END INPUT:");
     }
-  };
+
+    let mut func = func;
+
+    let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize;
+    let reg_universe = ir::make_universe(num_regs, num_regs);
+
+    let func_backup = func.clone();
+
+    let ra_result = regalloc::allocate_registers(
+        &mut func,
+        //TODO reenable checking once #47 is fixed.
+        regalloc::RegAllocAlgorithm::Backtracking,
+        &reg_universe,
+        /*request_block_annotations=*/ false,
+    );
+
+    match ra_result {
+        Ok(result) => {
+            func.update_from_alloc(result);
+            unsafe {
+                COUNTER_OK += 1;
+            }
+            return;
+        }
+        Err(err) => {
+            let mut stop = false;
+            if let regalloc::RegAllocError::RegChecker(_) = &err {
+                stop = true;
+                println!("==== fuzz_bt.rs: checker error: {:?}", err);
+            }
+            if stop {
+                let mut rendered = String::new();
+                func_backup
+                    .render("==== fuzz_bt.rs: failing input:", &mut rendered)
+                    .unwrap();
+                println!("{}", rendered);
+            }
+            println!("==== fuzz_bt.rs: failure reason: {}", err);
+            if stop {
+                println!("==== fuzz_bt.rs:");
+                println!(
+                    "==== fuzz_bt.rs: to repro, use flags '-f {} -i {}'",
+                    num_regs, num_regs
+                );
+                println!("==== fuzz_bt.rs:");
+                panic!("==== fuzz_bt.rs: STOPPING.  Bye! ====");
+            }
+        }
+    };
 });

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 

--- a/fuzz/fuzz_bt_differential.rs
+++ b/fuzz/fuzz_bt_differential.rs
@@ -5,50 +5,50 @@ use minira::{self, test_framework as ir, validator};
 use regalloc;
 
 fuzz_target!(|func: ir::Func| {
-  let mut func = func;
+    let mut func = func;
 
-  let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize;
-  let reg_universe = ir::make_universe(num_regs, num_regs);
+    let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize;
+    let reg_universe = ir::make_universe(num_regs, num_regs);
 
-  let cloned_func = func.clone();
+    let cloned_func = func.clone();
 
-  let mut rendered = String::new();
-  func.render("before allocation", &mut rendered).unwrap();
-  println!("{}", rendered);
+    let mut rendered = String::new();
+    func.render("before allocation", &mut rendered).unwrap();
+    println!("{}", rendered);
 
-  let result = match regalloc::allocate_registers(
-    &mut func,
-    // TODO reenable checking once #47 is fixed.
-    regalloc::RegAllocAlgorithm::Backtracking,
-    &reg_universe,
-    /*request_block_annotations=*/false
-  ) {
-    Ok(result) => result,
-    Err(err) => {
-      if let regalloc::RegAllocError::RegChecker(_) = &err {
-        panic!(format!("fuzz_bt_differential.rs: checker error: {:?}", err));
-      }
-      println!("allocation error: {}", err);
-      return;
-    }
-  };
+    let result = match regalloc::allocate_registers(
+        &mut func,
+        // TODO reenable checking once #47 is fixed.
+        regalloc::RegAllocAlgorithm::Backtracking,
+        &reg_universe,
+        /*request_block_annotations=*/ false,
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            if let regalloc::RegAllocError::RegChecker(_) = &err {
+                panic!(format!("fuzz_bt_differential.rs: checker error: {:?}", err));
+            }
+            println!("allocation error: {}", err);
+            return;
+        }
+    };
 
-  func.update_from_alloc(result);
-  func.print("after allocation", &None);
+    func.update_from_alloc(result);
+    func.print("after allocation", &None);
 
-  let expected = ir::run_func(
-    &cloned_func,
-    "Before allocation",
-    &reg_universe,
-    ir::RunStage::BeforeRegalloc,
-  );
+    let expected = ir::run_func(
+        &cloned_func,
+        "Before allocation",
+        &reg_universe,
+        ir::RunStage::BeforeRegalloc,
+    );
 
-  let observed = ir::run_func(
-    &func,
-    "After allocation",
-    &reg_universe,
-    ir::RunStage::AfterRegalloc,
-  );
+    let observed = ir::run_func(
+        &func,
+        "After allocation",
+        &reg_universe,
+        ir::RunStage::AfterRegalloc,
+    );
 
-  validator::check_results(&expected, &observed);
+    validator::check_results(&expected, &observed);
 });

--- a/fuzz/fuzz_lsra_differential.rs
+++ b/fuzz/fuzz_lsra_differential.rs
@@ -5,52 +5,55 @@ use minira::{self, test_framework as ir, validator};
 use regalloc;
 
 fuzz_target!(|func: ir::Func| {
-  let mut func = func;
+    let mut func = func;
 
-  // Add one register to be used as a scratch.
-  let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize + 1;
-  let reg_universe = ir::make_universe(num_regs, num_regs);
+    // Add one register to be used as a scratch.
+    let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize + 1;
+    let reg_universe = ir::make_universe(num_regs, num_regs);
 
-  let cloned_func = func.clone();
-  let expected = ir::run_func(
-    &cloned_func,
-    "Before allocation",
-    &reg_universe,
-    ir::RunStage::BeforeRegalloc,
-  );
-  if expected.is_err() {
-    return;
-  }
-
-  let mut rendered = String::new();
-  func.render("before allocation", &mut rendered).unwrap();
-  println!("{}", rendered);
-
-  let result = match regalloc::allocate_registers(
-    &mut func,
-    regalloc::RegAllocAlgorithm::LinearScanChecked,
-    &reg_universe,
-    /*request_block_annotations=*/false
-  ) {
-    Ok(result) => result,
-    Err(err) => {
-      if let regalloc::RegAllocError::RegChecker(_) = &err {
-        panic!(format!("fuzz_lsra_differential.rs: checker error: {:?}", err));
-      }
-      println!("allocation error: {}", err);
-      return;
+    let cloned_func = func.clone();
+    let expected = ir::run_func(
+        &cloned_func,
+        "Before allocation",
+        &reg_universe,
+        ir::RunStage::BeforeRegalloc,
+    );
+    if expected.is_err() {
+        return;
     }
-  };
 
-  func.update_from_alloc(result);
-  func.print("after allocation", &None);
+    let mut rendered = String::new();
+    func.render("before allocation", &mut rendered).unwrap();
+    println!("{}", rendered);
 
-  let observed = ir::run_func(
-    &func,
-    "After allocation",
-    &reg_universe,
-    ir::RunStage::AfterRegalloc,
-  );
+    let result = match regalloc::allocate_registers(
+        &mut func,
+        regalloc::RegAllocAlgorithm::LinearScanChecked,
+        &reg_universe,
+        /*request_block_annotations=*/ false,
+    ) {
+        Ok(result) => result,
+        Err(err) => {
+            if let regalloc::RegAllocError::RegChecker(_) = &err {
+                panic!(format!(
+                    "fuzz_lsra_differential.rs: checker error: {:?}",
+                    err
+                ));
+            }
+            println!("allocation error: {}", err);
+            return;
+        }
+    };
 
-  validator::check_results(&expected, &observed);
+    func.update_from_alloc(result);
+    func.print("after allocation", &None);
+
+    let observed = ir::run_func(
+        &func,
+        "After allocation",
+        &reg_universe,
+        ir::RunStage::AfterRegalloc,
+    );
+
+    validator::check_results(&expected, &observed);
 });

--- a/fuzz/fuzz_parser.rs
+++ b/fuzz/fuzz_parser.rs
@@ -4,23 +4,21 @@ use libfuzzer_sys::fuzz_target;
 use minira::{parser, test_framework as ir};
 
 fuzz_target!(|func: ir::Func| {
-  func.print("generated func");
+    func.print("generated func");
 
-  let mut printed = String::new();
-  func
-    .render("func", &mut printed)
-    .expect("error when printing the first time");
+    let mut printed = String::new();
+    func.render("func", &mut printed)
+        .expect("error when printing the first time");
 
-  let parsed_func =
-    parser::parse_content("funk", &printed).expect("parser error");
+    let parsed_func = parser::parse_content("funk", &printed).expect("parser error");
 
-  let mut reprinted = String::new();
-  parsed_func.render("func", &mut reprinted).unwrap();
+    let mut reprinted = String::new();
+    parsed_func.render("func", &mut reprinted).unwrap();
 
-  let reparsed_func = parser::parse_content("funk", &reprinted)
-    .expect("shouldn't error on the second parse!");
-  let mut rereprinted = String::new();
-  reparsed_func.render("func", &mut rereprinted).unwrap();
+    let reparsed_func =
+        parser::parse_content("funk", &reprinted).expect("shouldn't error on the second parse!");
+    let mut rereprinted = String::new();
+    reparsed_func.render("func", &mut rereprinted).unwrap();
 
-  assert_eq!(reprinted, rereprinted);
+    assert_eq!(reprinted, rereprinted);
 });

--- a/fuzz/fuzz_validator.rs
+++ b/fuzz/fuzz_validator.rs
@@ -4,15 +4,15 @@ use libfuzzer_sys::fuzz_target;
 use minira::{fuzzing, test_framework as ir, validator::validate};
 
 fuzz_target!(|func: ir::Func| {
-  let reg_universe = ir::make_universe(
-    fuzzing::NUM_REAL_REGS_PER_RC as usize,
-    fuzzing::NUM_REAL_REGS_PER_RC as usize,
-  );
+    let reg_universe = ir::make_universe(
+        fuzzing::NUM_REAL_REGS_PER_RC as usize,
+        fuzzing::NUM_REAL_REGS_PER_RC as usize,
+    );
 
-  validate(&func, &reg_universe).unwrap_or_else(|err| {
-    let mut rendered = String::new();
-    func.render("validation error", &mut rendered).unwrap();
-    println!("{}", rendered);
-    panic!(err);
-  });
+    validate(&func, &reg_universe).unwrap_or_else(|err| {
+        let mut rendered = String::new();
+        func.render("validation error", &mut rendered).unwrap();
+        println!("{}", rendered);
+        panic!(err);
+    });
 });

--- a/lib/src/analysis.rs
+++ b/lib/src/analysis.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 

--- a/lib/src/avl_tree.rs
+++ b/lib/src/avl_tree.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 //! AVL trees with a private allocation pool.
 //!
 //! AVL tree internals are public, so that backtracking.rs can do custom

--- a/lib/src/backtracking.rs
+++ b/lib/src/backtracking.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 //! Checker: verifies that spills/reloads/moves retain equivalent dataflow to original, vreg-based
 //! code.
 //!

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![allow(non_snake_case)]
 
 //! Data structures for the whole crate.

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 //! Main file / top-level module for regalloc library.
 //!
 //! We have tried hard to make the library's interface as simple as possible,

--- a/lib/src/linear_scan.rs
+++ b/lib/src/linear_scan.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 //! Implementation of the linear scan allocator algorithm.
 //!
 //! This tries to follow the implementation as suggested by:

--- a/lib/src/trees_maps_sets.rs
+++ b/lib/src/trees_maps_sets.rs
@@ -1,7 +1,3 @@
-/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 4 -*-
- * vim: set ts=8 sts=2 et sw=2 tw=80:
-*/
-
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 


### PR DESCRIPTION
 - Rename rustfmt.toml to .rustfmt.toml so that it's less prominent, and copy in the comment from Wasmtime's .rustfmt.toml
 - Run rustfmt on fuzz/*.rs
 - Remove emacs/vim modelines. As of #45, the code is using rustfmt defaults, so it's more convenient to have people configure their editors to follow this style by default for Rust code, because that's the style used in Cranelift, Wasmtime, and other projects.