### PR TITLE
Add `orig_insn_map`: mapping from original to new insn indices.

### DIFF
--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -435,21 +435,38 @@ macro_rules! generate_boilerplate {
             #[allow(dead_code)]
             #[inline(always)]
             pub fn new(n: u32) -> Self {
+                debug_assert!(n != u32::max_value());
                 Self::$TypeIx(n)
             }
             #[allow(dead_code)]
             #[inline(always)]
-            pub fn max_value() -> Self {
-                Self::$TypeIx(u32::max_value())
+            pub const fn max_value() -> Self {
+                Self::$TypeIx(u32::max_value() - 1)
             }
             #[allow(dead_code)]
             #[inline(always)]
-            pub fn min_value() -> Self {
+            pub const fn min_value() -> Self {
                 Self::$TypeIx(u32::min_value())
             }
             #[allow(dead_code)]
             #[inline(always)]
+            pub const fn invalid_value() -> Self {
+                Self::$TypeIx(u32::max_value())
+            }
+            #[allow(dead_code)]
+            #[inline(always)]
+            pub fn is_valid(self) -> bool {
+                self != Self::invalid_value()
+            }
+            #[allow(dead_code)]
+            #[inline(always)]
+            pub fn is_invalid(self) -> bool {
+                self == Self::invalid_value()
+            }
+            #[allow(dead_code)]
+            #[inline(always)]
             pub fn get(self) -> u32 {
+                debug_assert!(self.is_valid());
                 match self {
                     $TypeIx::$TypeIx(n) => n,
                 }
@@ -457,39 +474,49 @@ macro_rules! generate_boilerplate {
             #[allow(dead_code)]
             #[inline(always)]
             pub fn plus(self, delta: u32) -> $TypeIx {
+                debug_assert!(self.is_valid());
                 $TypeIx::$TypeIx(self.get() + delta)
             }
             #[allow(dead_code)]
             #[inline(always)]
             pub fn minus(self, delta: u32) -> $TypeIx {
+                debug_assert!(self.is_valid());
                 $TypeIx::$TypeIx(self.get() - delta)
             }
             #[allow(dead_code)]
             pub fn dotdot(&self, last_plus1: $TypeIx) -> Range<$TypeIx> {
+                debug_assert!(self.is_valid());
                 let len = (last_plus1.get() - self.get()) as usize;
                 Range::new(*self, len)
             }
         }
         impl fmt::Debug for $TypeIx {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                write!(fmt, "{}{}", $PrintingPrefix, &self.get())
+                if self.is_invalid() {
+                    write!(fmt, "{}<NONE>", $PrintingPrefix)
+                } else {
+                    write!(fmt, "{}{}", $PrintingPrefix, &self.get())
+                }
             }
         }
         impl PlusOne for $TypeIx {
             #[inline(always)]
             fn plus_one(&self) -> Self {
+                debug_assert!(self.is_valid());
                 self.plus(1)
             }
         }
         impl PlusN for $TypeIx {
             #[inline(always)]
             fn plus_n(&self, n: usize) -> Self {
+                debug_assert!(self.is_valid());
                 self.plus(n as u32)
             }
         }
         impl Into<u32> for $TypeIx {
             #[inline(always)]
             fn into(self) -> u32 {
+                debug_assert!(self.is_valid());
                 self.get()
             }
         }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -313,6 +313,16 @@ pub struct RegAllocResult<F: Function> {
     /// branch targets appropriately.
     pub target_map: TypedIxVec<BlockIx, InstIx>,
 
+    /// Full mapping from new instruction indices to original instruction
+    /// indices. May be needed by the client to, for example, update metadata
+    /// such as debug/source-location info as the instructions are spliced
+    /// and reordered.
+    ///
+    /// Each entry is an `InstIx`, but may be `InstIx::invalid_value()` if the
+    /// new instruction at this new index was inserted by the allocator
+    /// (i.e., if it is a load, spill or move instruction).
+    pub orig_insn_map: TypedIxVec</* new */ InstIx, /* orig */ InstIx>,
+
     /// Which real registers were overwritten? This will contain all real regs
     /// that appear as defs or modifies in register slots of the output
     /// instruction list.  This will only list registers that are available to

--- a/lib/src/linear_scan.rs
+++ b/lib/src/linear_scan.rs
@@ -3251,7 +3251,7 @@ fn apply_registers<F: Function>(
         use_checker,
     );
 
-    let (final_insns, target_map) = match final_insns_and_targetmap_or_err {
+    let (final_insns, target_map, orig_insn_map) = match final_insns_and_targetmap_or_err {
         Err(e) => return Err(e),
         Ok(pair) => pair,
     };
@@ -3295,6 +3295,7 @@ fn apply_registers<F: Function>(
     let ra_res = RegAllocResult {
         insns: final_insns,
         target_map,
+        orig_insn_map,
         clobbered_registers,
         num_spill_slots,
         block_annotations: None,


### PR DESCRIPTION
This is needed in the Cranelift client code in order to track
source-location mapping for debug info: we need to be able to shuffle
the source locations into the new locations after the regalloc has done
its instruction-stream editing. The `target_map` result is not quite
good enough, because it only provides old --> new mappings at a basic
block granularity.