### PR TITLE
Add options to configure the register allocator

### DIFF
--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -42,13 +42,14 @@ fuzz_target!(|func: ir::Func| {
 
     let func_backup = func.clone();
 
-    let ra_result = regalloc::allocate_registers(
-        &mut func,
+    let opts = regalloc::Options {
         //TODO reenable checking once #47 is fixed.
-        regalloc::RegAllocAlgorithm::Backtracking,
-        &reg_universe,
-        /*request_block_annotations=*/ false,
-    );
+        run_checker: false,
+
+        algorithm: regalloc::Algorithm::Backtracking(Default::default()),
+    };
+
+    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, opts);
 
     match ra_result {
         Ok(result) => {

--- a/fuzz/fuzz_bt_differential.rs
+++ b/fuzz/fuzz_bt_differential.rs
@@ -16,13 +16,14 @@ fuzz_target!(|func: ir::Func| {
     func.render("before allocation", &mut rendered).unwrap();
     println!("{}", rendered);
 
-    let result = match regalloc::allocate_registers(
-        &mut func,
-        // TODO reenable checking once #47 is fixed.
-        regalloc::RegAllocAlgorithm::Backtracking,
-        &reg_universe,
-        /*request_block_annotations=*/ false,
-    ) {
+    let opts = regalloc::Options {
+        //TODO reenable checking once #47 is fixed.
+        run_checker: false,
+
+        algorithm: regalloc::Algorithm::Backtracking(Default::default()),
+    };
+
+    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, opts) {
         Ok(result) => result,
         Err(err) => {
             if let regalloc::RegAllocError::RegChecker(_) = &err {

--- a/fuzz/fuzz_lsra_differential.rs
+++ b/fuzz/fuzz_lsra_differential.rs
@@ -28,9 +28,8 @@ fuzz_target!(|func: ir::Func| {
 
     let result = match regalloc::allocate_registers(
         &mut func,
-        regalloc::RegAllocAlgorithm::LinearScanChecked,
         &reg_universe,
-        /*request_block_annotations=*/ false,
+        regalloc::AlgorithmWithDefaults::LinearScan,
     ) {
         Ok(result) => result,
         Err(err) => {

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -5,6 +5,7 @@
 
 use log::{debug, info, log_enabled, Level};
 use smallvec::SmallVec;
+use std::default;
 use std::fmt;
 
 use crate::analysis_control_flow::InstIxToBlockIxMap;
@@ -25,6 +26,30 @@ use crate::inst_stream::{edit_inst_stream, InstToInsert, InstToInsertAndPoint};
 use crate::sparse_set::{SparseSet, SparseSetU};
 use crate::union_find::UnionFindEquivClasses;
 use crate::{Function, RegAllocError, RegAllocResult};
+
+#[derive(Clone)]
+pub struct BacktrackingOptions {
+    /// Should the register allocator generate block annotations?
+    pub request_block_annotations: bool,
+}
+
+impl default::Default for BacktrackingOptions {
+    fn default() -> Self {
+        Self {
+            request_block_annotations: false,
+        }
+    }
+}
+
+impl fmt::Debug for BacktrackingOptions {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "backtracking (block annotations: {})",
+            self.request_block_annotations
+        )
+    }
+}
 
 //=============================================================================
 // The per-real-register state
@@ -790,7 +815,7 @@ pub fn alloc_main<F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
     use_checker: bool,
-    request_block_annotations: bool,
+    opts: &BacktrackingOptions,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     // -------- Perform initial liveness analysis --------
     // Note that the analysis phase can fail; hence we propagate any error.
@@ -1818,7 +1843,7 @@ pub fn alloc_main<F: Function>(
 
     assert!(est_freqs.len() as usize == func.blocks().len());
     let mut block_annotations = None;
-    if request_block_annotations {
+    if opts.request_block_annotations {
         let mut anns = TypedIxVec::<BlockIx, Vec<String>>::new();
         for (estFreq, i) in est_freqs.iter().zip(0..) {
             let bix = BlockIx::new(i);

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -14,6 +14,7 @@ use log::{debug, info, log_enabled, trace, Level};
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::{Array, SmallVec};
 
+use std::default;
 use std::fmt;
 
 use crate::analysis_data_flow::add_raw_reg_vecs_for_insn;
@@ -24,6 +25,21 @@ use crate::{Function, RegAllocError, RegAllocResult};
 
 mod assign_registers;
 mod resolve_moves;
+
+#[derive(Clone)]
+pub struct LinearScanOptions;
+
+impl default::Default for LinearScanOptions {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl fmt::Debug for LinearScanOptions {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "linear scan")
+    }
+}
 
 // Helpers for SmallVec
 fn smallvec_append<A: Array>(dst: &mut SmallVec<A>, src: &mut SmallVec<A>)
@@ -896,6 +912,7 @@ pub(crate) fn run<F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
     use_checker: bool,
+    _opts: &LinearScanOptions,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     let (reg_uses, mut rlrs, mut vlrs, mut fragments, liveouts, _est_freqs, _inst_to_block_map) =
         run_analysis(func, reg_universe).map_err(|err| RegAllocError::Analysis(err))?;


### PR DESCRIPTION
This is an API breaking change. This allows selecting either a
preconfigured register allocator with sensible defaults, or to configure
options common to all the allocators and specific to each allocator.