### PR TITLE
Use incrementally-updated, dense vreg-to-rreg maps.

### DIFF
--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1734,7 +1734,6 @@ pub fn alloc_main<F: Function>(
         frag_map,
         &frag_env,
         &reg_universe,
-        false, // multiple blocks per frag
         use_checker,
     );
 

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -1031,7 +1031,6 @@ fn apply_registers<F: Function>(
         frag_map,
         fragments,
         reg_universe,
-        true, // multiple blocks per frag
         use_checker,
     )?;
 


### PR DESCRIPTION
This PR changes the interface of `map_regs()` to take, instead of two
Maps (a hashmap), two abstracted `RegVRMap` instances bundled together.
The implementation of this map is a dense vector indexed by vreg; in
almost all cases this should be faster than a hashmap.

Furthermore, this PR changes the instruction-stream editing to maintain
running incrementally-updated pre- and post-instruction maps, rather
than cloning the full hashmap twice for every instruction. A preliminary
investigation of Cranelift's new backend using DHAT shows that this
clone is very costly in terms of allocation; this interface and
algorithm change should significantly reduce the cost.