### PR TITLE
A semantics-level clean-up following implementation of `RangeFrag` co…

### DIFF
--- a/lib/src/linear_scan/assign_registers.rs
+++ b/lib/src/linear_scan/assign_registers.rs
@@ -1325,19 +1325,13 @@ fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> Int
             debug_assert!(parent_last <= child_first);
             debug_assert!(child_first <= child_last);
 
-            let bix = frag.bix;
-
             // Parent range.
-            let count = 1; // unused by LSRA.
-            let parent_frag =
-                RangeFrag::new_multi_block(state.func, bix, parent_first, parent_last, count);
-
+            let parent_frag = RangeFrag::new(parent_first, parent_last);
             let parent_frag_ix = RangeFragIx::new(state.fragments.len());
             state.fragments.push(parent_frag);
 
             // Child range.
-            let child_frag =
-                RangeFrag::new_multi_block(state.func, bix, child_first, child_last, count);
+            let child_frag = RangeFrag::new(child_first, child_last);
             let child_frag_ix = RangeFragIx::new(state.fragments.len());
             state.fragments.push(child_frag);
 
@@ -1356,10 +1350,7 @@ fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> Int
             "no fragments in the parent interval"
         );
 
-        let frag = &state.fragments[child_frag_ixs[0]];
-        let parent_frag =
-            RangeFrag::new_multi_block(state.func, frag.bix, at_pos, at_pos, /* count */ 1);
-
+        let parent_frag = RangeFrag::new(at_pos, at_pos);
         let parent_frag_ix = RangeFragIx::new(state.fragments.len());
         state.fragments.push(parent_frag);
 

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -774,17 +774,8 @@ fn ref_last_use(
     None
 }
 
-fn try_compress_ranges<F: Function>(
-    func: &F,
-    rlrs: &mut RealRanges,
-    vlrs: &mut VirtualRanges,
-    fragments: &mut Fragments,
-) {
-    fn compress<F: Function>(
-        func: &F,
-        frag_ixs: &mut SmallVec<[RangeFragIx; 4]>,
-        fragments: &mut Fragments,
-    ) {
+fn try_compress_ranges(rlrs: &mut RealRanges, vlrs: &mut VirtualRanges, fragments: &mut Fragments) {
+    fn compress(frag_ixs: &mut SmallVec<[RangeFragIx; 4]>, fragments: &mut Fragments) {
         if frag_ixs.len() == 1 {
             return;
         }
@@ -792,8 +783,7 @@ fn try_compress_ranges<F: Function>(
         let last_frag_end = fragments[*frag_ixs.last().unwrap()].last;
         let first_frag = &mut fragments[frag_ixs[0]];
 
-        let new_range =
-            RangeFrag::new_multi_block(func, first_frag.bix, first_frag.first, last_frag_end, 1);
+        let new_range = RangeFrag::new(first_frag.first, last_frag_end);
 
         let new_range_ix = RangeFragIx::new(fragments.len());
         fragments.push(new_range);
@@ -809,7 +799,7 @@ fn try_compress_ranges<F: Function>(
         //&& prev_frag.last.pt == Point::Def
         //&& cur_frag.first.pt == Point::Use
         //{
-        //let new_range = RangeFrag::new_multi_block(
+        //let (new_range, new_range_metrics) = RangeFrag::new_multi_block(
         //func,
         //prev_frag.bix,
         //prev_frag.first,
@@ -850,7 +840,7 @@ fn try_compress_ranges<F: Function>(
             }
         } else {
             // First time we see this vreg, compress and insert it.
-            compress(func, &mut vlr.sorted_frags.frag_ixs, fragments);
+            compress(&mut vlr.sorted_frags.frag_ixs, fragments);
             // TODO try to avoid the clone?
             by_vreg.insert(vlr.vreg, vlr.clone());
         }
@@ -897,8 +887,16 @@ pub(crate) fn run<F: Function>(
     reg_universe: &RealRegUniverse,
     use_checker: bool,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
-    let (reg_uses, mut rlrs, mut vlrs, mut fragments, liveouts, _est_freqs, _inst_to_block_map) =
-        run_analysis(func, reg_universe).map_err(|err| RegAllocError::Analysis(err))?;
+    let (
+        reg_uses,
+        mut rlrs,
+        mut vlrs,
+        mut fragments,
+        _fragment_metrics,
+        liveouts,
+        _est_freqs,
+        _inst_to_block_map,
+    ) = run_analysis(func, reg_universe).map_err(|err| RegAllocError::Analysis(err))?;
 
     let scratches_by_rc = {
         let mut scratches_by_rc = vec![None; NUM_REG_CLASSES];
@@ -922,7 +920,7 @@ pub(crate) fn run<F: Function>(
         scratches_by_rc
     };
 
-    try_compress_ranges(func, &mut rlrs, &mut vlrs, &mut fragments);
+    try_compress_ranges(&mut rlrs, &mut vlrs, &mut fragments);
 
     let intervals = Intervals::new(rlrs, vlrs, &fragments);
 


### PR DESCRIPTION
…mpression

in the backtracking allocator:

* split `RangeFrag` into `RangeFrag` and `RangeFragMetrics`

* in many places where before a vector of `RangeFrag`s was available, now we
  have two vectors of the same length, one of `RangeFrag`s and the other of
  `RangeFragMetrics`.

* add extensive commenting explaining this

* remove from LSRA all complexity to do with `RangeFrag` metrics, which was in
  any case unused

* as a ridealong, change some uses of the `RangeFrag` vector named `fenv` to
  `frag_env` so as to be consistent throughout the codebase, and a bit more
  descriptive.