### PR TITLE
Allow `block_succs` to return a Cow[BlockIx] instead of a Vec[BlockIx]

### DIFF
--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -46,8 +46,15 @@ fn main() {
                 .required(true)
                 .possible_values(&["bt", "lsra", "btc", "lsrac"])
                 .help("algorithm name"),
-        );
+        )
+        .arg(
+            clap::Arg::with_name("quiet")
+            .short("q")
+            .takes_value(false)
+            .help("whether to run in quiet mode (i.e. not print the function's body before and after regalloc)")
+    );
     let matches = app.get_matches();
+    let quiet = matches.is_present("quiet");
 
     let func_name = matches.value_of("test").unwrap();
     let mut func = match crate::test_cases::find_func(func_name) {
@@ -91,7 +98,9 @@ fn main() {
 
     let reg_universe = make_universe(num_regs_i32, num_regs_f32);
 
-    func.print("before allocation", &None);
+    if !quiet {
+        func.print("before allocation", &None);
+    }
 
     // Just so we can run it later.  Not needed for actual allocation.
     let original_func = func.clone();
@@ -110,7 +119,10 @@ fn main() {
     // interface to our specific test ISA.
     let mb_block_anns = result.block_annotations.clone();
     func.update_from_alloc(result);
-    func.print("after allocation", &mb_block_anns);
+
+    if !quiet {
+        func.print("after allocation", &mb_block_anns);
+    }
 
     let before_regalloc_result = run_func(
         &original_func,

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -5,7 +5,7 @@ use arbitrary::Arbitrary;
 use regalloc::*;
 use std::collections::HashSet;
 
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::validator::{validate, Context as ValidatorContext, RegRef};
 
@@ -2178,9 +2178,9 @@ impl regalloc::Function for Func {
     }
 
     /// Get CFG successors: indexed by block, provide a list of successor blocks.
-    fn block_succs(&self, block: BlockIx) -> Vec<BlockIx> {
+    fn block_succs(&self, block: BlockIx) -> Cow<[BlockIx]> {
         let last_insn = self.blocks[block].start.plus(self.blocks[block].len - 1);
-        self.insns[last_insn].get_targets()
+        Cow::Owned(self.insns[last_insn].get_targets())
     }
 
     fn is_ret(&self, insn: InstIx) -> bool {

--- a/lib/src/analysis_control_flow.rs
+++ b/lib/src/analysis_control_flow.rs
@@ -117,9 +117,8 @@ fn calc_preds_and_succs<F: Function>(
     // miss any edges.
     let mut succ_map = TypedIxVec::<BlockIx, SparseSetU<[BlockIx; 4]>>::new();
     for b in func.blocks() {
-        let succs = func.block_succs(b);
         let mut bix_set = SparseSetU::<[BlockIx; 4]>::empty();
-        for bix in succs.iter() {
+        for bix in func.block_succs(b).iter() {
             bix_set.insert(*bix);
         }
         succ_map.push(bix_set);

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -348,7 +348,7 @@ impl Checker {
 
         for block in f.blocks() {
             bb_in.insert(block, Default::default());
-            bb_succs.insert(block, f.block_succs(block));
+            bb_succs.insert(block, f.block_succs(block).to_vec());
             bb_insts.insert(block, vec![]);
         }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -30,7 +30,7 @@ mod union_find;
 
 use log::{info, log_enabled, Level};
 use std::default;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 // Stuff that is defined by the library
 
@@ -197,7 +197,7 @@ pub trait Function {
     fn block_insns(&self, block: BlockIx) -> Range<InstIx>;
 
     /// Get CFG successors for a given block.
-    fn block_succs(&self, block: BlockIx) -> Vec<BlockIx>;
+    fn block_succs(&self, block: BlockIx) -> Cow<[BlockIx]>;
 
     /// Determine whether an instruction is a return instruction.
     fn is_ret(&self, insn: InstIx) -> bool;

--- a/lib/src/linear_scan/resolve_moves.rs
+++ b/lib/src/linear_scan/resolve_moves.rs
@@ -226,7 +226,7 @@ pub(crate) fn run<F: Function>(
         // have at most one predecessor.
         let cur_has_one_succ = successors.len() == 1;
 
-        for succ in successors {
+        for &succ in successors.iter() {
             if !seen_successors.insert(succ) {
                 continue;
             }


### PR DESCRIPTION
In addition with a wasmtime PR (about to be posted), this helps reducing the number of memory allocations during compilations.

Also contains a small utility improvement: ability to not print the function's output onto stdout.