### PR TITLE
Mark fn get_sanitized_reg_uses_for_func as inline-always.  Reduces in…

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -435,7 +435,7 @@ pub fn get_sanitized_reg_uses_for_func<F: Function>(
 // convenience interface
 
 // ==== EXPORTED ====
-#[inline(never)]
+#[inline(always)]
 pub fn does_inst_use_def_or_mod_reg(
     rvb: &RegVecsAndBounds,
     iix: InstIx,


### PR DESCRIPTION
…sn count

for one spill-heavy input by around 1.4%.  Surprisingly high, but I think that
inlining means that the result triple never needs to be created.
No functional change.