### PR TITLE
/!\ Transform RegUsageMapper into a trait

### DIFF
--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -82,7 +82,7 @@ impl RI {
             RI::Imm { .. } => {}
         }
     }
-    fn apply_uses(&mut self, mapper: &RegUsageMapper) {
+    fn apply_uses<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         match self {
             RI::Reg { ref mut reg } => {
                 reg.apply_uses(mapper);
@@ -143,7 +143,7 @@ impl AM {
         }
     }
 
-    fn apply_uses(&mut self, mapper: &RegUsageMapper) {
+    fn apply_uses<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         match self {
             AM::RI { ref mut base, .. } => {
                 base.apply_uses(mapper);
@@ -948,7 +948,7 @@ impl Inst {
     }
 
     /// Apply the specified VirtualReg->RealReg mappings to the instruction,
-    pub fn map_regs(&mut self, mapper: &RegUsageMapper) {
+    pub fn map_regs<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         match self {
             Inst::NopZ {} => {}
             Inst::Imm { dst, imm: _ } => {
@@ -2201,7 +2201,7 @@ impl regalloc::Function for Func {
     /// to the instruction's effect) and defs (which semantically occur
     /// just after the instruction's effect). Regs that were "modified"
     /// can use either map; the vreg should be the same in both.
-    fn map_regs(insn: &mut Self::Inst, maps: &RegUsageMapper) {
+    fn map_regs<RUM: RegUsageMapper>(insn: &mut Self::Inst, maps: &RUM) {
         insn.map_regs(maps);
     }
 

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -57,11 +57,11 @@
 
 use crate::analysis_data_flow::get_san_reg_sets_for_insn;
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, Map, Point, RealReg, RealRegUniverse, Reg, RegSets, RegUsageMapper,
-    SpillSlot, VirtualReg, Writable,
+    BlockIx, InstIx, InstPoint, Map, Point, RealReg, RealRegUniverse, Reg, RegSets, SpillSlot,
+    VirtualReg, Writable,
 };
 use crate::inst_stream::InstToInsertAndPoint;
-use crate::Function;
+use crate::{Function, RegUsageMapper};
 
 use std::collections::VecDeque;
 use std::default::Default;
@@ -375,12 +375,12 @@ impl Checker {
     /// registers. The `SanitizedInstRegUses` must be the pre-allocation state;
     /// the `mapper` must be provided to give the virtual -> real mappings at
     /// the program points immediately before and after this instruction.
-    pub(crate) fn add_op(
+    pub(crate) fn add_op<RUM: RegUsageMapper>(
         &mut self,
         block: BlockIx,
         inst_ix: InstIx,
         regsets: &RegSets,
-        mapper: &RegUsageMapper,
+        mapper: &RUM,
     ) -> Result<(), CheckerErrors> {
         debug!(
             "add_op: block {} inst {} regsets {:?}",
@@ -512,13 +512,13 @@ impl CheckerContext {
 
     /// Update the checker with the given instruction and the given pre- and post-maps. Instructions
     /// within a block must be visited in program order.
-    pub(crate) fn handle_insn<F: Function>(
+    pub(crate) fn handle_insn<F: Function, RUM: RegUsageMapper>(
         &mut self,
         ru: &RealRegUniverse,
         func: &F,
         bix: BlockIx,
         iix: InstIx,
-        mapper: &RegUsageMapper,
+        mapper: &RUM,
     ) -> Result<(), CheckerErrors> {
         let empty = vec![];
         let pre_point = InstPoint::new(iix, Point::Reload);

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -9,12 +9,11 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::mem;
 use std::ops::Index;
 use std::ops::IndexMut;
 use std::slice::{Iter, IterMut};
 
-use crate::Function;
+use crate::{Function, RegUsageMapper};
 
 //=============================================================================
 // Queues
@@ -847,19 +846,19 @@ impl fmt::Debug for VirtualReg {
 impl Reg {
     /// Apply a vreg-rreg mapping to a Reg.  This is used for registers used in
     /// a read-role.
-    pub fn apply_uses(&mut self, mapper: &RegUsageMapper) {
+    pub fn apply_uses<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         self.apply(|vreg| mapper.get_use(vreg));
     }
 
     /// Apply a vreg-rreg mapping to a Reg.  This is used for registers used in
     /// a write-role.
-    pub fn apply_defs(&mut self, mapper: &RegUsageMapper) {
+    pub fn apply_defs<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         self.apply(|vreg| mapper.get_def(vreg));
     }
 
     /// Apply a vreg-rreg mapping to a Reg.  This is used for registers used in
     /// a modify-role.
-    pub fn apply_mods(&mut self, mapper: &RegUsageMapper) {
+    pub fn apply_mods<RUM: RegUsageMapper>(&mut self, mapper: &RUM) {
         self.apply(|vreg| mapper.get_mod(vreg));
     }
 
@@ -1136,170 +1135,6 @@ impl RegVecsAndBounds {
             regsets.mods.insert(self.vecs.mods[i]);
         }
         regsets
-    }
-}
-
-//=============================================================================
-// Register maps: virtual-to-real mapping.
-
-/// This data structure holds the mappings needed to map an instruction's uses,
-/// mods and defs from virtual to real registers.
-#[derive(Debug)]
-pub struct RegUsageMapper {
-    /// Dense vector-map indexed by virtual register number. This is consulted
-    /// directly for use-queries and augmented with the overlay for def-queries.
-    slots: Vec<RealReg>,
-
-    /// Overlay for def-queries. This is a set of updates that occurs "during"
-    /// the instruction in question, and will be applied to the slots array
-    /// once we are done processing this instruction (in preparation for
-    /// the next one).
-    overlay: SmallVec<[(VirtualReg, RealReg); 16]>,
-}
-
-impl RegUsageMapper {
-    /// Allocate a reg-usage mapper with the given predicted vreg capacity.
-    pub(crate) fn new(vreg_capacity: usize) -> RegUsageMapper {
-        RegUsageMapper {
-            slots: Vec::with_capacity(vreg_capacity),
-            overlay: SmallVec::new(),
-        }
-    }
-
-    /// Is the overlay past the sorted-size threshold?
-    fn is_overlay_large_enough_to_sort(&self) -> bool {
-        // Use the SmallVec spill-to-heap threshold as a threshold for "large
-        // enough to sort"; this has the effect of amortizing the cost of
-        // sorting along with the cost of copying out to heap memory, and also
-        // ensures that when we access heap (more likely to miss in cache), we
-        // do it with O(log N) accesses instead of O(N).
-        self.overlay.spilled()
-    }
-
-    /// Update the overlay.
-    pub(crate) fn set_overlay(&mut self, vreg: VirtualReg, rreg: Option<RealReg>) {
-        let rreg = rreg.unwrap_or(RealReg::invalid());
-        self.overlay.push((vreg, rreg));
-    }
-
-    /// Finish updates to the overlay, sorting if necessary.
-    pub(crate) fn finish_overlay(&mut self) {
-        if self.overlay.len() == 0 || !self.is_overlay_large_enough_to_sort() {
-            return;
-        }
-
-        // Sort stably, so that later updates continue to come after earlier
-        // ones.
-        self.overlay.sort_by_key(|pair| pair.0);
-        // Remove duplicates by collapsing runs of same-vreg pairs down to
-        // the last one.
-        let mut last_vreg = self.overlay[0].0;
-        let mut out = 0;
-        for i in 1..self.overlay.len() {
-            let this_vreg = self.overlay[i].0;
-            if this_vreg != last_vreg {
-                out += 1;
-            }
-            if i != out {
-                self.overlay[out] = self.overlay[i];
-            }
-            last_vreg = this_vreg;
-        }
-        let new_len = out + 1;
-        self.overlay.truncate(new_len);
-    }
-
-    /// Merge the overlay into the main map.
-    pub(crate) fn merge_overlay(&mut self) {
-        // Take the SmallVec and swap with empty to allow `&mut self` method
-        // call below.
-        let mappings = mem::replace(&mut self.overlay, SmallVec::new());
-        for (vreg, rreg) in mappings.into_iter() {
-            self.set_direct_internal(vreg, rreg);
-        }
-    }
-
-    /// Make a direct update to the mapping. Only usable when the overlay
-    /// is empty.
-    pub(crate) fn set_direct(&mut self, vreg: VirtualReg, rreg: Option<RealReg>) {
-        debug_assert!(self.overlay.is_empty());
-        let rreg = rreg.unwrap_or(RealReg::invalid());
-        self.set_direct_internal(vreg, rreg);
-    }
-
-    fn set_direct_internal(&mut self, vreg: VirtualReg, rreg: RealReg) {
-        let idx = vreg.get_index();
-        if idx >= self.slots.len() {
-            self.slots.resize(idx + 1, RealReg::invalid());
-        }
-        self.slots[idx] = rreg;
-    }
-
-    /// Perform a lookup directly in the main map. Returns `None` for
-    /// not-present.
-    fn lookup_direct(&self, vreg: VirtualReg) -> Option<RealReg> {
-        let idx = vreg.get_index();
-        if idx >= self.slots.len() {
-            None
-        } else {
-            Some(self.slots[idx])
-        }
-    }
-
-    /// Perform a lookup in the overlay. Returns `None` for not-present. No
-    /// fallback to main map (that happens in callers). Returns `Some` even
-    /// if mapped to `RealReg::invalid()`, because this is a tombstone
-    /// (represents deletion) in the overlay.
-    fn lookup_overlay(&self, vreg: VirtualReg) -> Option<RealReg> {
-        if self.is_overlay_large_enough_to_sort() {
-            // Do a binary search; we are guaranteed to have at most one
-            // matching because duplicates were collapsed after sorting.
-            if let Ok(idx) = self.overlay.binary_search_by_key(&vreg, |pair| pair.0) {
-                return Some(self.overlay[idx].1);
-            }
-        } else {
-            // Search in reverse order to find later updates first.
-            for &(this_vreg, this_rreg) in self.overlay.iter().rev() {
-                if this_vreg == vreg {
-                    return Some(this_rreg);
-                }
-            }
-        }
-        None
-    }
-
-    /// Sanity check: check that all slots are empty. Typically for use at the
-    /// end of processing as a debug-assert.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.overlay.iter().all(|pair| pair.1.is_invalid())
-            && self.slots.iter().all(|rreg| rreg.is_invalid())
-    }
-
-    // -- client-facing API: --
-
-    /// Return the `RealReg` if mapped, or `None`, for `vreg` occuring as a use
-    /// on the current instruction.
-    pub fn get_use(&self, vreg: VirtualReg) -> Option<RealReg> {
-        self.lookup_direct(vreg)
-            // Convert Some(RealReg::invalid()) to None.
-            .and_then(|reg| reg.maybe_valid())
-    }
-
-    /// Return the `RealReg` if mapped, or `None`, for `vreg` occuring as a def
-    /// on the current instruction.
-    pub fn get_def(&self, vreg: VirtualReg) -> Option<RealReg> {
-        self.lookup_overlay(vreg)
-            .or_else(|| self.lookup_direct(vreg))
-            // Convert Some(RealReg::invalid()) to None.
-            .and_then(|reg| reg.maybe_valid())
-    }
-
-    /// Return the `RealReg` if mapped, or `None`, for a `vreg` occuring as a
-    /// mod on the current instruction.
-    pub fn get_mod(&self, vreg: VirtualReg) -> Option<RealReg> {
-        let result = self.get_use(vreg);
-        debug_assert_eq!(result, self.get_def(vreg));
-        result
     }
 }
 
@@ -2142,125 +1977,6 @@ impl fmt::Debug for VirtualRange {
             " sz={}, tc={}, sc={:?}, {:?})",
             self.size, self.total_cost, self.spill_cost, self.sorted_frags
         )
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    fn vreg(idx: u32) -> VirtualReg {
-        Reg::new_virtual(RegClass::I64, idx).to_virtual_reg()
-    }
-    fn rreg(idx: u8) -> RealReg {
-        Reg::new_real(RegClass::I64, /* enc = */ 0, /* index = */ idx).to_real_reg()
-    }
-
-    #[test]
-    fn test_reg_use_mapper() {
-        let mut mapper = RegUsageMapper::new(/* estimated vregs = */ 16);
-        assert_eq!(None, mapper.get_use(vreg(0)));
-        assert_eq!(None, mapper.get_def(vreg(0)));
-        assert_eq!(None, mapper.get_mod(vreg(0)));
-
-        mapper.set_direct(vreg(0), Some(rreg(1)));
-        mapper.set_direct(vreg(1), Some(rreg(2)));
-
-        assert_eq!(Some(rreg(1)), mapper.get_use(vreg(0)));
-        assert_eq!(Some(rreg(1)), mapper.get_def(vreg(0)));
-        assert_eq!(Some(rreg(1)), mapper.get_mod(vreg(0)));
-        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
-        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
-        assert_eq!(Some(rreg(2)), mapper.get_mod(vreg(1)));
-
-        mapper.set_overlay(vreg(0), Some(rreg(3)));
-        mapper.set_overlay(vreg(2), Some(rreg(4)));
-        mapper.finish_overlay();
-
-        assert_eq!(Some(rreg(1)), mapper.get_use(vreg(0)));
-        assert_eq!(Some(rreg(3)), mapper.get_def(vreg(0)));
-        // vreg 0 not valid for mod (use and def differ).
-        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
-        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
-        assert_eq!(Some(rreg(2)), mapper.get_mod(vreg(1)));
-        assert_eq!(None, mapper.get_use(vreg(2)));
-        assert_eq!(Some(rreg(4)), mapper.get_def(vreg(2)));
-        // vreg 2 not valid for mod (use and def differ).
-
-        mapper.merge_overlay();
-        assert_eq!(Some(rreg(3)), mapper.get_use(vreg(0)));
-        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
-        assert_eq!(Some(rreg(4)), mapper.get_use(vreg(2)));
-        assert_eq!(None, mapper.get_use(vreg(3)));
-
-        // Check tombstoning behavior.
-        mapper.set_overlay(vreg(0), None);
-        mapper.finish_overlay();
-        assert_eq!(Some(rreg(3)), mapper.get_use(vreg(0)));
-        assert_eq!(None, mapper.get_def(vreg(0)));
-        mapper.merge_overlay();
-
-        // Check large (sorted) overlay mode.
-        for i in (2..50).rev() {
-            mapper.set_overlay(vreg(i), Some(rreg((i + 100) as u8)));
-        }
-        mapper.finish_overlay();
-        assert_eq!(None, mapper.get_use(vreg(0)));
-        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
-        assert_eq!(Some(rreg(4)), mapper.get_use(vreg(2)));
-        for i in 2..50 {
-            assert_eq!(Some(rreg((i + 100) as u8)), mapper.get_def(vreg(i)));
-        }
-        mapper.merge_overlay();
-
-        for i in (0..100).rev() {
-            mapper.set_overlay(vreg(i), None);
-        }
-        mapper.finish_overlay();
-        for i in 0..100 {
-            assert_eq!(None, mapper.get_def(vreg(i)));
-        }
-        assert_eq!(false, mapper.is_empty());
-        mapper.merge_overlay();
-        assert_eq!(true, mapper.is_empty());
-
-        // Check multiple-update behavior in small mode.
-        mapper.set_overlay(vreg(1), Some(rreg(1)));
-        mapper.set_overlay(vreg(1), Some(rreg(2)));
-        mapper.finish_overlay();
-        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
-        mapper.merge_overlay();
-        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
-
-        mapper.set_overlay(vreg(1), Some(rreg(2)));
-        mapper.set_overlay(vreg(1), None);
-        mapper.finish_overlay();
-        assert_eq!(None, mapper.get_def(vreg(1)));
-        mapper.merge_overlay();
-        assert_eq!(None, mapper.get_use(vreg(1)));
-
-        // Check multiple-update behavior in sorted mode.
-        for i in 0..100 {
-            mapper.set_overlay(vreg(2), Some(rreg(i)));
-        }
-        for i in 0..100 {
-            mapper.set_overlay(vreg(2), Some(rreg(2 * i)));
-        }
-        mapper.finish_overlay();
-        assert_eq!(Some(rreg(198)), mapper.get_def(vreg(2)));
-        mapper.merge_overlay();
-        assert_eq!(Some(rreg(198)), mapper.get_use(vreg(2)));
-
-        for i in 0..100 {
-            mapper.set_overlay(vreg(2), Some(rreg(i)));
-        }
-        for _ in 0..100 {
-            mapper.set_overlay(vreg(2), None);
-        }
-        mapper.finish_overlay();
-        assert_eq!(None, mapper.get_def(vreg(50)));
-        mapper.merge_overlay();
-        assert_eq!(None, mapper.get_use(vreg(50)));
     }
 }
 

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -1,10 +1,10 @@
 use crate::checker::Inst as CheckerInst;
 use crate::checker::{CheckerContext, CheckerErrors};
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, RangeFrag, RealReg, RealRegUniverse, RegUsageMapper, SpillSlot,
-    TypedIxVec, VirtualReg, Writable,
+    BlockIx, InstIx, InstPoint, RangeFrag, RealReg, RealRegUniverse, SpillSlot, TypedIxVec,
+    VirtualReg, Writable,
 };
-use crate::{Function, RegAllocError};
+use crate::{reg_maps::VrangeRegUsageMapper, Function, RegAllocError};
 use log::trace;
 
 use std::result::Result;
@@ -146,7 +146,7 @@ fn map_vregs_to_rregs<F: Function>(
 
     // Allocate the "mapper" data structure that we update incrementally and
     // pass to instruction reg-mapping routines to query.
-    let mut mapper = RegUsageMapper::new(vreg_estimate);
+    let mut mapper = VrangeRegUsageMapper::new(vreg_estimate);
 
     fn is_sane(frag: &RangeFrag) -> bool {
         // "Normal" frag (unrelated to spilling).  No normal frag may start or

--- a/lib/src/reg_maps.rs
+++ b/lib/src/reg_maps.rs
@@ -1,0 +1,290 @@
+use crate::{RealReg, RegUsageMapper, VirtualReg};
+use smallvec::SmallVec;
+use std::mem;
+
+/// This data structure holds the mappings needed to map an instruction's uses, mods and defs from
+/// virtual to real registers.
+///
+/// It remembers the sets of mappings (of a virtual register to a real register) over time, based
+/// on precise virtual ranges and their allocations.
+///
+/// This is the right implementation to use when a register allocation algorithm keeps track of
+/// precise virtual ranges, and maintains them over time.
+#[derive(Debug)]
+pub struct VrangeRegUsageMapper {
+    /// Dense vector-map indexed by virtual register number. This is consulted
+    /// directly for use-queries and augmented with the overlay for def-queries.
+    slots: Vec<RealReg>,
+
+    /// Overlay for def-queries. This is a set of updates that occurs "during"
+    /// the instruction in question, and will be applied to the slots array
+    /// once we are done processing this instruction (in preparation for
+    /// the next one).
+    overlay: SmallVec<[(VirtualReg, RealReg); 16]>,
+}
+
+impl VrangeRegUsageMapper {
+    /// Allocate a reg-usage mapper with the given predicted vreg capacity.
+    pub(crate) fn new(vreg_capacity: usize) -> VrangeRegUsageMapper {
+        VrangeRegUsageMapper {
+            slots: Vec::with_capacity(vreg_capacity),
+            overlay: SmallVec::new(),
+        }
+    }
+
+    /// Is the overlay past the sorted-size threshold?
+    fn is_overlay_large_enough_to_sort(&self) -> bool {
+        // Use the SmallVec spill-to-heap threshold as a threshold for "large
+        // enough to sort"; this has the effect of amortizing the cost of
+        // sorting along with the cost of copying out to heap memory, and also
+        // ensures that when we access heap (more likely to miss in cache), we
+        // do it with O(log N) accesses instead of O(N).
+        self.overlay.spilled()
+    }
+
+    /// Update the overlay.
+    pub(crate) fn set_overlay(&mut self, vreg: VirtualReg, rreg: Option<RealReg>) {
+        let rreg = rreg.unwrap_or(RealReg::invalid());
+        self.overlay.push((vreg, rreg));
+    }
+
+    /// Finish updates to the overlay, sorting if necessary.
+    pub(crate) fn finish_overlay(&mut self) {
+        if self.overlay.len() == 0 || !self.is_overlay_large_enough_to_sort() {
+            return;
+        }
+
+        // Sort stably, so that later updates continue to come after earlier
+        // ones.
+        self.overlay.sort_by_key(|pair| pair.0);
+        // Remove duplicates by collapsing runs of same-vreg pairs down to
+        // the last one.
+        let mut last_vreg = self.overlay[0].0;
+        let mut out = 0;
+        for i in 1..self.overlay.len() {
+            let this_vreg = self.overlay[i].0;
+            if this_vreg != last_vreg {
+                out += 1;
+            }
+            if i != out {
+                self.overlay[out] = self.overlay[i];
+            }
+            last_vreg = this_vreg;
+        }
+        let new_len = out + 1;
+        self.overlay.truncate(new_len);
+    }
+
+    /// Merge the overlay into the main map.
+    pub(crate) fn merge_overlay(&mut self) {
+        // Take the SmallVec and swap with empty to allow `&mut self` method
+        // call below.
+        let mappings = mem::replace(&mut self.overlay, SmallVec::new());
+        for (vreg, rreg) in mappings.into_iter() {
+            self.set_direct_internal(vreg, rreg);
+        }
+    }
+
+    /// Make a direct update to the mapping. Only usable when the overlay
+    /// is empty.
+    pub(crate) fn set_direct(&mut self, vreg: VirtualReg, rreg: Option<RealReg>) {
+        debug_assert!(self.overlay.is_empty());
+        let rreg = rreg.unwrap_or(RealReg::invalid());
+        self.set_direct_internal(vreg, rreg);
+    }
+
+    fn set_direct_internal(&mut self, vreg: VirtualReg, rreg: RealReg) {
+        let idx = vreg.get_index();
+        if idx >= self.slots.len() {
+            self.slots.resize(idx + 1, RealReg::invalid());
+        }
+        self.slots[idx] = rreg;
+    }
+
+    /// Perform a lookup directly in the main map. Returns `None` for
+    /// not-present.
+    fn lookup_direct(&self, vreg: VirtualReg) -> Option<RealReg> {
+        let idx = vreg.get_index();
+        if idx >= self.slots.len() {
+            None
+        } else {
+            Some(self.slots[idx])
+        }
+    }
+
+    /// Perform a lookup in the overlay. Returns `None` for not-present. No
+    /// fallback to main map (that happens in callers). Returns `Some` even
+    /// if mapped to `RealReg::invalid()`, because this is a tombstone
+    /// (represents deletion) in the overlay.
+    fn lookup_overlay(&self, vreg: VirtualReg) -> Option<RealReg> {
+        if self.is_overlay_large_enough_to_sort() {
+            // Do a binary search; we are guaranteed to have at most one
+            // matching because duplicates were collapsed after sorting.
+            if let Ok(idx) = self.overlay.binary_search_by_key(&vreg, |pair| pair.0) {
+                return Some(self.overlay[idx].1);
+            }
+        } else {
+            // Search in reverse order to find later updates first.
+            for &(this_vreg, this_rreg) in self.overlay.iter().rev() {
+                if this_vreg == vreg {
+                    return Some(this_rreg);
+                }
+            }
+        }
+        None
+    }
+
+    /// Sanity check: check that all slots are empty. Typically for use at the
+    /// end of processing as a debug-assert.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.overlay.iter().all(|pair| pair.1.is_invalid())
+            && self.slots.iter().all(|rreg| rreg.is_invalid())
+    }
+}
+
+impl RegUsageMapper for VrangeRegUsageMapper {
+    /// Return the `RealReg` if mapped, or `None`, for `vreg` occuring as a use
+    /// on the current instruction.
+    fn get_use(&self, vreg: VirtualReg) -> Option<RealReg> {
+        self.lookup_direct(vreg)
+            // Convert Some(RealReg::invalid()) to None.
+            .and_then(|reg| reg.maybe_valid())
+    }
+
+    /// Return the `RealReg` if mapped, or `None`, for `vreg` occuring as a def
+    /// on the current instruction.
+    fn get_def(&self, vreg: VirtualReg) -> Option<RealReg> {
+        self.lookup_overlay(vreg)
+            .or_else(|| self.lookup_direct(vreg))
+            // Convert Some(RealReg::invalid()) to None.
+            .and_then(|reg| reg.maybe_valid())
+    }
+
+    /// Return the `RealReg` if mapped, or `None`, for a `vreg` occuring as a
+    /// mod on the current instruction.
+    fn get_mod(&self, vreg: VirtualReg) -> Option<RealReg> {
+        let result = self.get_use(vreg);
+        debug_assert_eq!(result, self.get_def(vreg));
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Reg, RegClass, VirtualReg};
+
+    fn vreg(idx: u32) -> VirtualReg {
+        Reg::new_virtual(RegClass::I64, idx).to_virtual_reg()
+    }
+    fn rreg(idx: u8) -> RealReg {
+        Reg::new_real(RegClass::I64, /* enc = */ 0, /* index = */ idx).to_real_reg()
+    }
+
+    #[test]
+    fn test_reg_use_mapper() {
+        let mut mapper = VrangeRegUsageMapper::new(/* estimated vregs = */ 16);
+        assert_eq!(None, mapper.get_use(vreg(0)));
+        assert_eq!(None, mapper.get_def(vreg(0)));
+        assert_eq!(None, mapper.get_mod(vreg(0)));
+
+        mapper.set_direct(vreg(0), Some(rreg(1)));
+        mapper.set_direct(vreg(1), Some(rreg(2)));
+
+        assert_eq!(Some(rreg(1)), mapper.get_use(vreg(0)));
+        assert_eq!(Some(rreg(1)), mapper.get_def(vreg(0)));
+        assert_eq!(Some(rreg(1)), mapper.get_mod(vreg(0)));
+        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
+        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
+        assert_eq!(Some(rreg(2)), mapper.get_mod(vreg(1)));
+
+        mapper.set_overlay(vreg(0), Some(rreg(3)));
+        mapper.set_overlay(vreg(2), Some(rreg(4)));
+        mapper.finish_overlay();
+
+        assert_eq!(Some(rreg(1)), mapper.get_use(vreg(0)));
+        assert_eq!(Some(rreg(3)), mapper.get_def(vreg(0)));
+        // vreg 0 not valid for mod (use and def differ).
+        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
+        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
+        assert_eq!(Some(rreg(2)), mapper.get_mod(vreg(1)));
+        assert_eq!(None, mapper.get_use(vreg(2)));
+        assert_eq!(Some(rreg(4)), mapper.get_def(vreg(2)));
+        // vreg 2 not valid for mod (use and def differ).
+
+        mapper.merge_overlay();
+        assert_eq!(Some(rreg(3)), mapper.get_use(vreg(0)));
+        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
+        assert_eq!(Some(rreg(4)), mapper.get_use(vreg(2)));
+        assert_eq!(None, mapper.get_use(vreg(3)));
+
+        // Check tombstoning behavior.
+        mapper.set_overlay(vreg(0), None);
+        mapper.finish_overlay();
+        assert_eq!(Some(rreg(3)), mapper.get_use(vreg(0)));
+        assert_eq!(None, mapper.get_def(vreg(0)));
+        mapper.merge_overlay();
+
+        // Check large (sorted) overlay mode.
+        for i in (2..50).rev() {
+            mapper.set_overlay(vreg(i), Some(rreg((i + 100) as u8)));
+        }
+        mapper.finish_overlay();
+        assert_eq!(None, mapper.get_use(vreg(0)));
+        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
+        assert_eq!(Some(rreg(4)), mapper.get_use(vreg(2)));
+        for i in 2..50 {
+            assert_eq!(Some(rreg((i + 100) as u8)), mapper.get_def(vreg(i)));
+        }
+        mapper.merge_overlay();
+
+        for i in (0..100).rev() {
+            mapper.set_overlay(vreg(i), None);
+        }
+        mapper.finish_overlay();
+        for i in 0..100 {
+            assert_eq!(None, mapper.get_def(vreg(i)));
+        }
+        assert_eq!(false, mapper.is_empty());
+        mapper.merge_overlay();
+        assert_eq!(true, mapper.is_empty());
+
+        // Check multiple-update behavior in small mode.
+        mapper.set_overlay(vreg(1), Some(rreg(1)));
+        mapper.set_overlay(vreg(1), Some(rreg(2)));
+        mapper.finish_overlay();
+        assert_eq!(Some(rreg(2)), mapper.get_def(vreg(1)));
+        mapper.merge_overlay();
+        assert_eq!(Some(rreg(2)), mapper.get_use(vreg(1)));
+
+        mapper.set_overlay(vreg(1), Some(rreg(2)));
+        mapper.set_overlay(vreg(1), None);
+        mapper.finish_overlay();
+        assert_eq!(None, mapper.get_def(vreg(1)));
+        mapper.merge_overlay();
+        assert_eq!(None, mapper.get_use(vreg(1)));
+
+        // Check multiple-update behavior in sorted mode.
+        for i in 0..100 {
+            mapper.set_overlay(vreg(2), Some(rreg(i)));
+        }
+        for i in 0..100 {
+            mapper.set_overlay(vreg(2), Some(rreg(2 * i)));
+        }
+        mapper.finish_overlay();
+        assert_eq!(Some(rreg(198)), mapper.get_def(vreg(2)));
+        mapper.merge_overlay();
+        assert_eq!(Some(rreg(198)), mapper.get_use(vreg(2)));
+
+        for i in 0..100 {
+            mapper.set_overlay(vreg(2), Some(rreg(i)));
+        }
+        for _ in 0..100 {
+            mapper.set_overlay(vreg(2), None);
+        }
+        mapper.finish_overlay();
+        assert_eq!(None, mapper.get_def(vreg(50)));
+        mapper.merge_overlay();
+        assert_eq!(None, mapper.get_use(vreg(50)));
+    }
+}


### PR DESCRIPTION
This allows several implementations of RegUsageMapper to co-exist
without the client being aware of it.

This also renames the existing RegUsageMapper to VrangeRegUsageMapper,
since it tracks the mappings for the whole lifetime of given virtual
ranges. It is moved to its own file "reg_maps.rs", to reduce the size of the bag of All The Things also known as data_structures.rs. LSRA's own implementation of RegUsageMapper could also go there.

A few functions need to get a type parameter, and they get monomorphized
at compile-time.