### PR TITLE
BT: avoid construction of "no-evict" sets

### DIFF
--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -1882,12 +1882,15 @@ impl fmt::Debug for SpillCost {
 }
 
 impl SpillCost {
+    #[inline(always)]
     pub fn zero() -> Self {
         SpillCost::Finite(0.0)
     }
+    #[inline(always)]
     pub fn infinite() -> Self {
         SpillCost::Infinite
     }
+    #[inline(always)]
     pub fn finite(cost: f32) -> Self {
         // "`is_normal` returns true if the number is neither zero, infinite,
         // subnormal, or NaN."
@@ -1898,21 +1901,25 @@ impl SpillCost {
         assert!(cost < 1e18);
         SpillCost::Finite(cost)
     }
+    #[inline(always)]
     pub fn is_zero(&self) -> bool {
         match self {
             SpillCost::Infinite => false,
             SpillCost::Finite(c) => *c == 0.0,
         }
     }
+    #[inline(always)]
     pub fn is_infinite(&self) -> bool {
         match self {
             SpillCost::Infinite => true,
             SpillCost::Finite(_) => false,
         }
     }
+    #[inline(always)]
     pub fn is_finite(&self) -> bool {
         !self.is_infinite()
     }
+    #[inline(always)]
     pub fn is_less_than(&self, other: &Self) -> bool {
         match (self, other) {
             // Dubious .. both are infinity
@@ -1925,6 +1932,7 @@ impl SpillCost {
             (SpillCost::Finite(c1), SpillCost::Finite(c2)) => c1 < c2,
         }
     }
+    #[inline(always)]
     pub fn add(&mut self, other: &Self) {
         match (*self, other) {
             (SpillCost::Finite(c1), SpillCost::Finite(c2)) => {

--- a/lib/src/union_find.rs
+++ b/lib/src/union_find.rs
@@ -147,6 +147,9 @@ impl<T: ToFromU32> UnionFind<T> {
     }
 }
 
+//=============================================================================
+// UnionFindEquivClasses
+
 // This is a compact representation for all the equivalence classes in a
 // `UnionFind`, that can be constructed in more-or-less linear time (meaning,
 // O(universe size), and allows iteration over the elements of each
@@ -345,6 +348,32 @@ impl<T: ToFromU32> UnionFind<T> {
     }
 }
 
+impl<T: ToFromU32> UnionFindEquivClasses<T> {
+    // Indicates whether `item1` and `item2` are in the same equivalence
+    // class.  If either falls outside the "universe", returns `None`.
+    pub fn in_same_equivalence_class(&self, item1: T, item2: T) -> Option<bool> {
+        let mut item1num = ToFromU32::to_u32(item1) as usize;
+        let mut item2num = ToFromU32::to_u32(item2) as usize;
+        // If either item is outside our "universe", say we don't know.
+        if item1num >= self.heads.len() || item2num >= self.heads.len() {
+            return None;
+        }
+        // Ensure that `item1num` and `item2num` both point at class leaders.
+        if (self.heads[item1num] & 0x8000_0000) == 0 {
+            item1num = self.heads[item1num] as usize;
+        }
+        if (self.heads[item2num] & 0x8000_0000) == 0 {
+            item2num = self.heads[item2num] as usize;
+        }
+        debug_assert!((self.heads[item1num] & 0x8000_0000) == 0x8000_0000);
+        debug_assert!((self.heads[item2num] & 0x8000_0000) == 0x8000_0000);
+        Some(item1num == item2num)
+    }
+}
+
+//=============================================================================
+// UnionFindEquivClassElemsIter
+
 // We may want to find the equivalence class for some given element, and
 // iterate through its elements.  This iterator provides that.
 
@@ -431,7 +460,8 @@ impl<'a, T: ToFromU32> Iterator for UnionFindEquivClassLeadersIter<'a, T> {
     }
 }
 
-// ====== Testing machinery for UnionFind ======
+//=============================================================================
+// Testing machinery for UnionFind
 
 #[cfg(test)]
 mod union_find_test_utils {
@@ -473,6 +503,16 @@ mod union_find_test_utils {
             univ_expected.push(i);
         }
         assert!(univ_actual == univ_expected);
+    }
+    // Test that `in_same_equivalence_class` produces the expected results.
+    pub fn test_in_same_eclass(
+        eclasses: &UnionFindEquivClasses<u32>,
+        elem1: u32,
+        elem2: u32,
+        expected: Option<bool>,
+    ) {
+        assert!(eclasses.in_same_equivalence_class(elem1, elem2) == expected);
+        assert!(eclasses.in_same_equivalence_class(elem2, elem1) == expected);
     }
 }
 
@@ -526,6 +566,46 @@ fn test_union_find() {
     union_find_test_utils::test_eclass(&uf_eclasses, 6, &vec![6]);
     union_find_test_utils::test_eclass(&uf_eclasses, 7, &vec![7]);
     union_find_test_utils::test_leaders(UNIV_SIZE, &uf_eclasses, &vec![0, 1, 2, 6, 7]);
+    // At this point, also check the "in same equivalence class?" function.
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 0, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 1, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 2, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 3, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 4, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 5, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 1, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 2, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 3, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 4, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 5, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 1, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 2, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 3, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 4, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 5, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 2, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 3, 3, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 3, 4, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 3, 5, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 3, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 3, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 4, 4, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 4, 5, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 4, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 4, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 5, 5, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 5, 6, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 5, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 6, 6, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 6, 7, Some(false));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 7, 7, Some(true));
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 0, 8, None);
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 8, 0, None);
+    union_find_test_utils::test_in_same_eclass(&uf_eclasses, 8, 8, None);
 
     uf.union(7, 1);
     uf_eclasses = uf.get_equiv_classes();


### PR DESCRIPTION
When BT searches for a usable register to hold a VLR that belongs to an
equivalence class of VLRs (as determined by the coalescing analysis), it is
important not to choose for eviction, any other member of that class.  That
would undermine the whole point of coalescing.  It wouldn't lead to incorrect
allocations, though.

Until now, BT constructed, for each VLR, a SparseSet holding all the VLRs in
the same equivalence class, and passed it to `find_evict_set`.
`find_evict_set` then checks this set and will not request eviction of any
member in it.  The sets are constructed by consulting the
`UnionFindEquivClasses` created by coalescing analysis.

This works, but is wasteful: if there is a large equivalence class (of VLRs)
containing N elements, then the same no-evict set, of size N, will be
constructed N times.  This is quadratically bad in the worst case.

This patch removes all of the set construction and testing.  Instead,
`UnionFindEquivClasses` is enhanced so that it can directly answer the
question "are these two items in the same equivalence class?"  Then, a
suitable closure that calls the new function is passed to `find_evict_set`,
and that uses it to make the same evict/no-evict decision that it previously
did via set-membership tests of the no-evict set.

A closely related ridealong fix, is that all of the methods of `struct
SpillCost` are now marked as inline-always.  They were called a lot from
`find_evict_set` and so the inlining is a significant win.

Overall, for huge functions (`joey_big.clif`) this reduces insn count by 6.4%
and the number of malloc calls by 25.4% (!).