### PR TITLE
A few memory enhancements

### DIFF
--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -956,6 +956,7 @@ impl fmt::Debug for SpillSlot {
 pub struct RegUsageCollector<'a> {
     pub reg_vecs: &'a mut RegVecs,
 }
+
 impl<'a> RegUsageCollector<'a> {
     pub fn new(reg_vecs: &'a mut RegVecs) -> Self {
         Self { reg_vecs }
@@ -963,27 +964,28 @@ impl<'a> RegUsageCollector<'a> {
     pub fn add_use(&mut self, r: Reg) {
         self.reg_vecs.uses.push(r);
     }
-    pub fn add_uses(&mut self, regs: &Set<Reg>) {
-        for reg in regs.iter() {
-            self.add_use(*reg);
-        }
+    pub fn add_uses(&mut self, regs: &[Reg]) {
+        self.reg_vecs.uses.extend(regs.iter());
     }
     pub fn add_def(&mut self, r: Writable<Reg>) {
         self.reg_vecs.defs.push(r.to_reg());
     }
-    pub fn add_defs(&mut self, regs: &Set<Writable<Reg>>) {
-        for reg in regs.iter() {
-            self.add_def(*reg);
+    pub fn add_defs(&mut self, regs: &[Writable<Reg>]) {
+        self.reg_vecs.defs.reserve(regs.len());
+        for r in regs {
+            self.reg_vecs.defs.push(r.to_reg());
         }
     }
     pub fn add_mod(&mut self, r: Writable<Reg>) {
         self.reg_vecs.mods.push(r.to_reg());
     }
-    pub fn add_mods(&mut self, regs: &Set<Writable<Reg>>) {
-        for reg in regs.iter() {
-            self.add_mod(*reg);
+    pub fn add_mods(&mut self, regs: &[Writable<Reg>]) {
+        self.reg_vecs.mods.reserve(regs.len());
+        for r in regs {
+            self.reg_vecs.mods.push(r.to_reg());
         }
     }
+
     // The presence of the following two is a hack, needed to support fuzzing
     // in the test framework.  Real clients should not call them.
     pub fn get_use_def_mod_vecs_test_framework_only(&self) -> (Vec<Reg>, Vec<Reg>, Vec<Reg>) {
@@ -993,6 +995,7 @@ impl<'a> RegUsageCollector<'a> {
             self.reg_vecs.mods.clone(),
         )
     }
+
     pub fn get_empty_reg_vecs_test_framework_only(sanitized: bool) -> RegVecs {
         RegVecs::new(sanitized)
     }

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -33,6 +33,7 @@ pub type Map<K, V> = FxHashMap<K, V>;
 // Sets of things
 
 // Same comment as above for FxHashMap.
+#[derive(Clone)]
 pub struct Set<T> {
     set: FxHashSet<T>,
 }
@@ -197,17 +198,6 @@ impl<T: Eq + Ord + Hash + Copy + fmt::Debug> fmt::Debug for Set<T> {
         }
         s = s + &"}".to_string();
         write!(fmt, "{}", s)
-    }
-}
-
-impl<T: Eq + Ord + Hash + Copy + Clone + fmt::Debug> Clone for Set<T> {
-    #[inline(never)]
-    fn clone(&self) -> Self {
-        let mut res = Set::<T>::empty();
-        for item in self.set.iter() {
-            res.set.insert(item.clone());
-        }
-        res
     }
 }
 


### PR DESCRIPTION
This series of commits reduce the number of memory allocations during compilation with Cranelift:

- first commit uses the default implementation of Clone for Set, which is more efficient (as it avoids reallocations) and has the same effect.
- second commit reduces the number of allocations in get_range_frags, by: flushing RangeFrag as they're created instead of accumulating them in a Vec flushed at the end; reusing memory across block iterations. Some of this work might be undone by Julian's future patches, but it's a direct improvement here.
- The last commit (breaking change) requires that add_uses/add_defs are given Slices of Reg/WritableReg instead of Sets, which reduces the number of memory allocations, when combined with a symmetrical patch in Cranelift.

Each commit has been tested for performance separately and did improve all the metrics (icount, number of malloc'd bytes and blocks), when tested on joey-big/joey-medium/regex-rs.wasm test cases. For the latter, it's a 9% icount decrease, 19% block allocations decrease, 10% total of allocated bytes decrease.