### PR TITLE
Remove all `Map` uses from `get_range_frags` and `get_range_frags_for…

### DIFF
--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -188,12 +188,12 @@ pub fn run_analysis<F: Function>(
     // VirtualRanges and RealRanges.
     info!("  run_analysis: begin liveness analysis");
 
-    let (frag_ixs_per_reg, frag_env, frag_metrics_env) = get_range_frags(
+    let (frag_ixs_per_reg, frag_env, frag_metrics_env, vreg_classes) = get_range_frags(
         func,
-        &livein_sets_per_block,
-        &liveout_sets_per_block,
         &reg_vecs_and_bounds,
         &reg_universe,
+        &livein_sets_per_block,
+        &liveout_sets_per_block,
     );
 
     let (rlr_env, vlr_env) = merge_range_frags(
@@ -202,6 +202,8 @@ pub fn run_analysis<F: Function>(
         &frag_metrics_env,
         &estimated_frequencies,
         &cfg_info,
+        &reg_universe,
+        &vreg_classes,
     );
 
     debug_assert!(liveout_sets_per_block.len() == estimated_frequencies.len());

--- a/lib/src/sparse_set.rs
+++ b/lib/src/sparse_set.rs
@@ -70,6 +70,7 @@ where
             SparseSetU::Small { card, arr } => {
                 assert!(*card == A::size());
                 let mut set = FxHashSet::<A::Item>::default();
+                set.reserve(A::size());
                 // Could this be done faster?
                 let arr_p = arr.as_mut_ptr() as *mut A::Item;
                 for i in 0..*card {
@@ -253,20 +254,11 @@ where
         }
     }
 
-    #[inline(never)]
+    #[inline(always)]
     pub fn contains(&self, item: A::Item) -> bool {
         match self {
             SparseSetU::Large { set } => set.contains(&item),
-            SparseSetU::Small { card, arr } => {
-                assert!(*card <= A::size());
-                let arr_p = arr.as_ptr() as *const A::Item;
-                for i in 0..*card {
-                    if unsafe { read(arr_p.add(i)) } == item {
-                        return true;
-                    }
-                }
-                false
-            }
+            SparseSetU::Small { card, arr } => small_contains(*card, arr, item),
         }
     }
 


### PR DESCRIPTION
…_block`

This patch replaces them with vectors which are indexed by "unified reg index",
which is explained in comments in the patch.  There are two such vectors:

* `out_map`: this contains a SmallVec of RangeFragIxs for each Reg.  This is
  the overall result of `get_range_frags`.

* `state`: this is used in each call to `get_range_frags_for_block`, to keep
  track of the ProtoRangeFrag state for each register as we move through the
  block.  It replaces the previous Map based mapping.

One complication is that we no longer have available, the keys (Regs) for
`state`.  Those are needed so as to know which entries to flush at the end of
`get_range_frags_for_block`.  To solve this, the `state` indices that each
call to `get_range_frags_for_block` visits, are stored in a new vector
`visited`, and that is used to drive the end-of-function flushing.

To avoid repeatedly allocating `visited`, it is allocated/owned by
`get_range_frags`, and passed to each call to `get_range_frags_for_block`.

`get_range_frags` also now has to determine the number of virtual regs, and
the RegClass for each, in order that `get_range_frags_for_block` and later
`merge_range_frags` can map from "unified register index" back to the original
Reg values.

`merge_range_frags` is adjusted to take input in the new format (vectors
instead of maps).

enum RegClass acquires a new value, ::INVALID, to facilitate incremental
construction of the abovementioned mapping from virtual regs to their classes.

Ridealong and minor mods:

* new function `Reg::get_index_u32`, so as to avoid usize-to-u32-and-back
  casts when working with `Reg::get_index` -- these functions are now hot.

* `SparseSetU::upgrade`: use a stragically-placed `reserve` call to avoid
  a few allocations later.

* `SparseSetU::contains`: use an existing function to loop over the small
  array, rather than duplicating code.  Also, make this inline-always; it
  is hot.

Overall, this reduces the number of blocks allocated by 15% (joey_small.clif)
to 19% (joey_big.clif) and the insn count by 0% (joey_big.clif) to 3.5%
(joey_med.clif).