### PR TITLE
Linear scan: use a binary heap for unallocated intervals + malloc improvements

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -826,16 +826,16 @@ impl fmt::Debug for ProtoRangeFrag {
 // making it feasible to represent sets of registers using bit sets.
 
 #[inline(always)]
-fn reg_to_reg_ix(n_real_regs: u32, r: Reg) -> u32 {
+pub(crate) fn reg_to_reg_ix(num_real_regs: u32, r: Reg) -> u32 {
     if r.is_real() {
         r.get_index_u32()
     } else {
-        n_real_regs + r.get_index_u32()
+        num_real_regs + r.get_index_u32()
     }
 }
 
 #[inline(always)]
-fn reg_ix_to_reg(
+pub(crate) fn reg_ix_to_reg(
     reg_universe: &RealRegUniverse,
     vreg_classes: &Vec</*vreg index,*/ RegClass>,
     reg_ix: u32,

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -11,7 +11,7 @@ use crate::{
     AnalysisError, Function, RealRegUniverse, RegClass, TypedIxVec,
 };
 use log::{debug, info, log_enabled, Level};
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use std::{fmt, mem};
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -336,7 +336,7 @@ fn get_range_frags_for_block<F: Function>(
                     state[r_state_ix] = Some(RangeFrag {
                         first: new_pt,
                         last: new_pt,
-                        mentions: vec![(iix, mention_set)],
+                        mentions: smallvec![(iix, mention_set)],
                     })
                 }
 
@@ -396,7 +396,7 @@ fn get_range_frags_for_block<F: Function>(
                 bix,
                 pf.first,
                 pf.last,
-                mem::replace(&mut pf.mentions, Vec::new()),
+                mem::replace(&mut pf.mentions, MentionMap::new()),
             );
             emit_range_frag(r, frag, frag_metrics, num_real_regs);
             state[*r_state_ix as usize] = None;
@@ -786,7 +786,7 @@ fn flush_interval(
                 RangeFrag {
                     first: frag.first,
                     last: frag.last,
-                    mentions: mem::replace(&mut frag.mentions, Vec::new()),
+                    mentions: mem::replace(&mut frag.mentions, MentionMap::new()),
                 }
             }));
         return;

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -58,8 +58,8 @@ impl RangeFrag {
         )
     }
 
-    // TODO pass by value, not by ref, here
     #[inline(always)]
+    #[cfg(debug_assertions)]
     pub(crate) fn contains(&self, inst: &InstPoint) -> bool {
         self.first <= *inst && *inst <= self.last
     }

--- a/lib/src/linear_scan/assign_registers.rs
+++ b/lib/src/linear_scan/assign_registers.rs
@@ -1164,7 +1164,12 @@ fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> Int
         Err(index) => (index, false),
     };
 
-    let mut child_mentions = parent_mentions.split_off(index);
+    // Emulate split_off for SmallVec here.
+    let mut child_mentions = MentionMap::with_capacity(parent_mentions.len() - index);
+    for mention in parent_mentions.iter().skip(index) {
+        child_mentions.push(mention.clone());
+    }
+    parent_mentions.truncate(index);
 
     // In the situation where we split at the def point of an instruction, and the mention set
     // contains the use point, we need to refine the sets:

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -127,7 +127,7 @@ impl fmt::Debug for LinearScanOptions {
 type RegUses = RegVecsAndBounds;
 
 /// A unique identifier for an interval.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 struct IntId(pub(crate) usize);
 
 impl fmt::Debug for IntId {
@@ -595,12 +595,12 @@ pub(crate) fn run<F: Function>(
         stats,
     )?;
 
-    let virtuals = intervals.virtuals;
+    let virtuals = &intervals.virtuals;
 
     let memory_moves = resolve_moves::run(
         func,
         &reg_uses,
-        &virtuals,
+        virtuals,
         &liveins,
         &liveouts,
         &mut num_spill_slots,
@@ -609,7 +609,7 @@ pub(crate) fn run<F: Function>(
 
     apply_registers(
         func,
-        &virtuals,
+        virtuals,
         memory_moves,
         reg_universe,
         num_spill_slots,

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use analysis::{AnalysisInfo, RangeFrag};
+use smallvec::SmallVec;
 
 mod analysis;
 mod assign_registers;
@@ -219,7 +220,8 @@ impl VirtualInterval {
     }
 }
 
-// TODO comment
+/// This data structure tracks the mentions of a register (virtual or real) at a precise
+/// instruction point. It's a set encoded as three flags, one for each of use/mod/def.
 #[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Mention(u8);
 
@@ -285,7 +287,7 @@ impl Mention {
     }
 }
 
-pub type MentionMap = Vec<(InstIx, Mention)>;
+pub type MentionMap = SmallVec<[(InstIx, Mention); 2]>;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Location {


### PR DESCRIPTION
- Use a bin-heap for the queue of to-be-allocated intervals, since the full complexity of an AVL tree is not required, and this is conceptually kind of a priority queue.
- Backport the analysis changes back to LSRA's analysis. This is a nice win, thanks @julian-seward1 :)
- Use `smallvec` for VirtualInterval's mentions, based on a distribution of real-world mentions per virtual interval. Interestingly, the best results come with an initial size of 2, because in all the three programs used for benchmarking (in #74), the third quartile of number of mentions per virtual interval was 1 or 2.

Overall, this is a nice win in reducing the number of mallocs and calls in recursive functions. This is a LSRA speedup of 23% for joey_smallest, 18% for joey_medium and 14% for joey_big.