### PR TITLE
Bugfix and API adjustment for reference types support.

### DIFF
--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -121,7 +121,7 @@ fn main() {
     // Just so we can run it later.  Not needed for actual allocation.
     let original_func = func.clone();
 
-    let result = match allocate_registers_with_opts(&mut func, &reg_universe, &None, opts.clone()) {
+    let result = match allocate_registers_with_opts(&mut func, &reg_universe, None, opts.clone()) {
         Err(e) => {
             println!("allocation failed: {}", e);
             return;
@@ -274,7 +274,7 @@ mod test_utils {
             &reg_universe,
             RunStage::BeforeRegalloc,
         );
-        let result = allocate_registers_with_opts(&mut func, &reg_universe, &None, opts)
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
             .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });
@@ -301,7 +301,7 @@ mod test_utils {
         allocate_registers(
             &mut func,
             &reg_universe,
-            &None,
+            None,
             AlgorithmWithDefaults::LinearScan,
         )
     }
@@ -329,7 +329,7 @@ mod test_utils {
             .allocate(opts.clone())
             .expect("generic allocator failed!");
 
-        let result = allocate_registers_with_opts(&mut func, &reg_universe, &None, opts)
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
             .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });
@@ -375,9 +375,8 @@ mod test_utils {
                 .allocate(opts.clone())
                 .expect("generic allocator failed!");
 
-            let result =
-                allocate_registers_with_opts(&mut func, &reg_universe, &None, opts.clone())
-                    .expect("regalloc failure");
+            let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts.clone())
+                .expect("regalloc failure");
 
             func.update_from_alloc(result);
             func.print("AFTER", &None);

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -49,7 +49,7 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, &None, opts);
+    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, None, opts);
 
     match ra_result {
         Ok(result) => {

--- a/fuzz/fuzz_bt_differential.rs
+++ b/fuzz/fuzz_bt_differential.rs
@@ -23,7 +23,8 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, &None, opts) {
+    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
+    {
         Ok(result) => result,
         Err(err) => {
             if let regalloc::RegAllocError::RegChecker(_) = &err {

--- a/fuzz/fuzz_lsra.rs
+++ b/fuzz/fuzz_lsra.rs
@@ -18,7 +18,7 @@ fuzz_target!(|func: ir::Func| {
     let result = match regalloc::allocate_registers(
         &mut func,
         &reg_universe,
-        &None,
+        None,
         regalloc::AlgorithmWithDefaults::LinearScan,
     ) {
         Ok(result) => result,

--- a/fuzz/fuzz_lsra_differential.rs
+++ b/fuzz/fuzz_lsra_differential.rs
@@ -29,7 +29,7 @@ fuzz_target!(|func: ir::Func| {
     let result = match regalloc::allocate_registers(
         &mut func,
         &reg_universe,
-        &None,
+        None,
         regalloc::AlgorithmWithDefaults::LinearScan,
     ) {
         Ok(result) => result,

--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -8,10 +8,10 @@ use std::fmt;
 use crate::analysis_control_flow::CFGInfo;
 use crate::data_structures::{
     BlockIx, InstIx, InstPoint, MoveInfo, MoveInfoElem, Point, Queue, RangeFrag, RangeFragIx,
-    RangeFragKind, RangeFragMetrics, RealRange, RealRangeIx, RealReg, RealRegUniverse, Reg,
-    RegClass, RegSets, RegToRangesMaps, RegUsageCollector, RegVecBounds, RegVecs, RegVecsAndBounds,
-    SortedRangeFragIxs, SortedRangeFrags, SpillCost, TypedIxVec, VirtualRange, VirtualRangeIx,
-    VirtualReg,
+    RangeFragKind, RangeFragMetrics, RangeId, RealRange, RealRangeIx, RealReg, RealRegUniverse,
+    Reg, RegClass, RegSets, RegToRangesMaps, RegUsageCollector, RegVecBounds, RegVecs,
+    RegVecsAndBounds, SortedRangeFragIxs, SortedRangeFrags, SpillCost, TypedIxVec, VirtualRange,
+    VirtualRangeIx, VirtualReg,
 };
 use crate::sparse_set::SparseSet;
 use crate::union_find::{ToFromU32, UnionFind};
@@ -1870,13 +1870,40 @@ pub fn compute_reg_to_ranges_maps<F: Function>(
     }
 }
 
-// Collect info about registers that are connected by moves:
+// Collect info about registers (and optionally Virtual/RealRanges) that are
+// connected by moves:
 #[inline(never)]
 pub fn collect_move_info<F: Function>(
     func: &F,
     reg_vecs_and_bounds: &RegVecsAndBounds,
     est_freqs: &TypedIxVec<BlockIx, u32>,
+    reg_to_ranges_maps: &RegToRangesMaps,
+    rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
+    vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
+    fenv: &TypedIxVec<RangeFragIx, RangeFrag>,
+    want_ranges: bool,
 ) -> MoveInfo {
+    // Helper: find the RealRange or VirtualRange for a register at an InstPoint.
+    let find_range_for_reg = |pt: InstPoint, reg: Reg| {
+        if !want_ranges {
+            return RangeId::invalid_value();
+        }
+        if reg.is_real() {
+            for &rlrix in &reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize] {
+                if rlr_env[rlrix].sorted_frags.contains_pt(fenv, pt) {
+                    return RangeId::new_real(rlrix);
+                }
+            }
+        } else {
+            for &vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize] {
+                if vlr_env[vlrix].sorted_frags.contains_pt(pt) {
+                    return RangeId::new_virtual(vlrix);
+                }
+            }
+        }
+        RangeId::invalid_value()
+    };
+
     let mut moves = Vec::<MoveInfoElem>::new();
     for b in func.blocks() {
         let block_eef = est_freqs[b];
@@ -1908,9 +1935,18 @@ pub fn collect_move_info<F: Function>(
                         let dst = wreg.to_reg();
                         let src = reg;
                         let est_freq = block_eef;
+
+                        // Find the ranges for source and dest, if requested.
+                        let (src_range, dst_range) = (
+                            find_range_for_reg(InstPoint::new(iix, Point::Use), src),
+                            find_range_for_reg(InstPoint::new(iix, Point::Def), dst),
+                        );
+
                         moves.push(MoveInfoElem {
                             dst,
+                            dst_range,
                             src,
+                            src_range,
                             iix,
                             est_freq,
                         });

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -277,6 +277,11 @@ pub fn run_analysis<F: Function>(
             func,
             &reg_vecs_and_bounds,
             &estimated_frequencies,
+            reg_to_ranges_maps.as_ref().unwrap(),
+            &rlr_env,
+            &vlr_env,
+            &frag_env,
+            /* want_ranges = */ client_wants_stackmaps,
         ))
     } else {
         None

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -251,6 +251,7 @@ pub fn do_coalescing_analysis<F: Function>(
         src,
         iix,
         est_freq,
+        ..
     } in &move_info.moves
     {
         debug!(

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -453,6 +453,8 @@ fn get_stackmap_artefacts_at(
     }
     let rci = rci.unwrap();
 
+    debug!("computing stackmap info at {:?}", pt);
+
     for rreg_no in rci.first..rci.last + 1 {
         // Get the RangeId, if any, assigned for `rreg_no` at `iix.u`.  From that we can figure
         // out if it is reftyped.
@@ -460,8 +462,18 @@ fn get_stackmap_artefacts_at(
         if let Some(range_id) = mb_range_id {
             // `rreg_no` is live at `iix.u`.
             let is_ref = if range_id.is_real() {
+                debug!(
+                    " real reg {:?} is real-range {:?}",
+                    rreg_no,
+                    rlr_env[range_id.to_real()]
+                );
                 rlr_env[range_id.to_real()].is_ref
             } else {
+                debug!(
+                    " real reg {:?} is virtual-range {:?}",
+                    rreg_no,
+                    vlr_env[range_id.to_virtual()]
+                );
                 vlr_env[range_id.to_virtual()].is_ref
             };
             if is_ref {
@@ -471,6 +483,8 @@ fn get_stackmap_artefacts_at(
             }
         }
     }
+
+    debug!("Sbefore = {:?}", s_before);
 
     // Compute Safter.
 
@@ -489,6 +503,8 @@ fn get_stackmap_artefacts_at(
             s_after.delete(r_defd.to_real_reg());
         }
     }
+
+    debug!("Safter = {:?}", s_before);
 
     // Create the spill insns, as defined by Sbefore.  This has the side effect of recording the
     // spill in `spill_slot_allocator`, so we can later ask it to tell us all the reftyped spill
@@ -532,6 +548,8 @@ fn get_stackmap_artefacts_at(
     // hold values of reftyped regs that are live over this instruction.
 
     let reftyped_spillslots = spill_slot_allocator.get_reftyped_spillslots_at_inst_point(pt);
+
+    debug!("reftyped_spillslots = {:?}", reftyped_spillslots);
 
     // And we're done!
 

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -641,7 +641,7 @@ impl fmt::Debug for EditListItem {
 pub fn alloc_main<F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
-    stackmap_request: &Option<StackmapRequestInfo>,
+    stackmap_request: Option<&StackmapRequestInfo>,
     use_checker: bool,
     opts: &BacktrackingOptions,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
@@ -650,11 +650,11 @@ pub fn alloc_main<F: Function>(
     let empty_vec_iixs = vec![];
     let (client_wants_stackmaps, reftype_class, reftyped_vregs, safepoint_insns) =
         match stackmap_request {
-            Some(StackmapRequestInfo {
+            Some(&StackmapRequestInfo {
                 reftype_class,
-                reftyped_vregs,
-                safepoint_insns,
-            }) => (true, *reftype_class, reftyped_vregs, safepoint_insns),
+                ref reftyped_vregs,
+                ref safepoint_insns,
+            }) => (true, reftype_class, reftyped_vregs, safepoint_insns),
             None => (false, RegClass::INVALID, &empty_vec_vregs, &empty_vec_iixs),
         };
 

--- a/lib/src/bt_spillslot_allocator.rs
+++ b/lib/src/bt_spillslot_allocator.rs
@@ -468,7 +468,7 @@ impl SpillSlotAllocator {
         // must succeed.  Calling recursively is a bit stupid in the sense that we then search
         // again to find the slot we just allocated, but hey.
         self.add_new_slot(1 /*word*/);
-        return self.alloc_reftyped_spillslot_for_frag(frag); // \o/ tailcall \o/
+        self.alloc_reftyped_spillslot_for_frag(frag) // \o/ tailcall \o/
     }
 
     // STACKMAP SUPPORT

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -1794,6 +1794,22 @@ impl SortedRangeFragIxs {
         res.check(fenv);
         res
     }
+
+    /// Does this sorted list of range fragments contain the given instruction point?
+    pub fn contains_pt(&self, fenv: &TypedIxVec<RangeFragIx, RangeFrag>, pt: InstPoint) -> bool {
+        self.frag_ixs
+            .binary_search_by(|&ix| {
+                let frag = &fenv[ix];
+                if pt < frag.first {
+                    Ordering::Less
+                } else if pt >= frag.first && pt <= frag.last {
+                    Ordering::Equal
+                } else {
+                    Ordering::Greater
+                }
+            })
+            .is_ok()
+    }
 }
 
 //=============================================================================
@@ -1855,6 +1871,21 @@ impl SortedRangeFrags {
                 }
             }
         }
+    }
+
+    /// Does this sorted list of range fragments contain the given instruction point?
+    pub fn contains_pt(&self, pt: InstPoint) -> bool {
+        self.frags
+            .binary_search_by(|frag| {
+                if pt < frag.first {
+                    Ordering::Less
+                } else if pt >= frag.first && pt <= frag.last {
+                    Ordering::Equal
+                } else {
+                    Ordering::Greater
+                }
+            })
+            .is_ok()
     }
 }
 
@@ -2094,7 +2125,9 @@ pub struct RegToRangesMaps {
 
 pub struct MoveInfoElem {
     pub dst: Reg,
+    pub dst_range: RangeId, // possibly RangeId::invalid_value() if not requested
     pub src: Reg,
+    pub src_range: RangeId, // possibly RangeId::invalid_value() if not requested
     pub iix: InstIx,
     pub est_freq: u32,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -496,7 +496,7 @@ pub struct StackmapRequestInfo {
 pub fn allocate_registers_with_opts<F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
-    stackmap_info: &Option<StackmapRequestInfo>,
+    stackmap_info: Option<&StackmapRequestInfo>,
     opts: Options,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     info!("");
@@ -510,10 +510,10 @@ pub fn allocate_registers_with_opts<F: Function>(
         }
     }
     // If stackmap support has been requested, perform some initial sanity checks.
-    if let Some(StackmapRequestInfo {
+    if let Some(&StackmapRequestInfo {
         reftype_class,
-        reftyped_vregs,
-        safepoint_insns,
+        ref reftyped_vregs,
+        ref safepoint_insns,
     }) = stackmap_info
     {
         if let Algorithm::LinearScan(_) = opts.algorithm {
@@ -521,7 +521,7 @@ pub fn allocate_registers_with_opts<F: Function>(
                 "stackmap request: not currently available for Linear Scan".to_string(),
             ));
         }
-        if *reftype_class != RegClass::I64 && *reftype_class != RegClass::I32 {
+        if reftype_class != RegClass::I64 && reftype_class != RegClass::I32 {
             return Err(RegAllocError::Other(
                 "stackmap request: invalid reftype_class".to_string(),
             ));
@@ -529,7 +529,7 @@ pub fn allocate_registers_with_opts<F: Function>(
         let num_avail_vregs = func.get_num_vregs();
         for i in 0..reftyped_vregs.len() {
             let vreg = &reftyped_vregs[i];
-            if vreg.get_class() != *reftype_class {
+            if vreg.get_class() != reftype_class {
                 return Err(RegAllocError::Other(
                     "stackmap request: invalid vreg class".to_string(),
                 ));
@@ -596,7 +596,7 @@ pub fn allocate_registers_with_opts<F: Function>(
 pub fn allocate_registers<F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
-    stackmap_info: &Option<StackmapRequestInfo>,
+    stackmap_info: Option<&StackmapRequestInfo>,
     algorithm: AlgorithmWithDefaults,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     let algorithm = match algorithm {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -466,7 +466,7 @@ pub struct StackmapRequestInfo {
 
     /// The virtual regs that hold reftyped values.  These must be provided in ascending order
     /// of register index and be duplicate-free.  They must have class `reftype_class`.
-    reftyped_vregs: Vec<VirtualReg>,
+    pub reftyped_vregs: Vec<VirtualReg>,
 
     /// The indices of instructions for which the allocator will construct stackmaps.  These
     /// must be provided in ascending order and be duplicate-free.  The specified instructions
@@ -475,7 +475,7 @@ pub struct StackmapRequestInfo {
     /// though).  The reason is that, at a safepoint, the client's garbage collector may change
     /// the values of all live references, so it would be meaningless for a safepoint
     /// instruction also to attempt to do that -- we'd end up with two competing new values.
-    safepoint_insns: Vec<InstIx>,
+    pub safepoint_insns: Vec<InstIx>,
 }
 
 /// Allocate registers for a function's code, given a universe of real registers that we are

--- a/lib/src/snapshot.rs
+++ b/lib/src/snapshot.rs
@@ -161,7 +161,7 @@ impl IRSnapshot {
         allocate_registers_with_opts(
             &mut self.func,
             &self.reg_universe,
-            &None, /*no stackmap request*/
+            None, /*no stackmap request*/
             opts,
         )
     }


### PR DESCRIPTION
This PR fixes a small bug in the reference-type support from #80, and makes a minor API adjustment.

In particular, this bugfix ensures that the "reffyness" computation is as precise as we need it to be (by propagating reffyness only to specific ranges associated with registers, rather than all of them, since e.g. a given rreg might be reffy at one program-point but not another).

Tested by integrating into Cranelift (PR over there will be created once this lands) and then into SpiderMonkey from there (patch also pending).

I'll plan to add checker support to verify stackmaps so that we can fuzz this and have a bit more confidence in it.