### PR TITLE
Initial implementation of reftypes support in the allocator (currentl…

### DIFF
--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -121,7 +121,7 @@ fn main() {
     // Just so we can run it later.  Not needed for actual allocation.
     let original_func = func.clone();
 
-    let result = match allocate_registers_with_opts(&mut func, &reg_universe, opts.clone()) {
+    let result = match allocate_registers_with_opts(&mut func, &reg_universe, &None, opts.clone()) {
         Err(e) => {
             println!("allocation failed: {}", e);
             return;
@@ -274,8 +274,8 @@ mod test_utils {
             &reg_universe,
             RunStage::BeforeRegalloc,
         );
-        let result =
-            allocate_registers_with_opts(&mut func, &reg_universe, opts).unwrap_or_else(|err| {
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, &None, opts)
+            .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });
 
@@ -298,7 +298,12 @@ mod test_utils {
         let _ = pretty_env_logger::try_init();
         let mut func = test_cases::find_func(func_name).unwrap();
         let reg_universe = make_universe(num_gpr, num_fpu);
-        allocate_registers(&mut func, &reg_universe, AlgorithmWithDefaults::LinearScan)
+        allocate_registers(
+            &mut func,
+            &reg_universe,
+            &None,
+            AlgorithmWithDefaults::LinearScan,
+        )
     }
 
     // Note: num_gpr/num_fpu: must include the scratch register.
@@ -324,8 +329,8 @@ mod test_utils {
             .allocate(opts.clone())
             .expect("generic allocator failed!");
 
-        let result =
-            allocate_registers_with_opts(&mut func, &reg_universe, opts).unwrap_or_else(|err| {
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, &None, opts)
+            .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });
         func.update_from_alloc(result);
@@ -370,8 +375,9 @@ mod test_utils {
                 .allocate(opts.clone())
                 .expect("generic allocator failed!");
 
-            let result = allocate_registers_with_opts(&mut func, &reg_universe, opts.clone())
-                .expect("regalloc failure");
+            let result =
+                allocate_registers_with_opts(&mut func, &reg_universe, &None, opts.clone())
+                    .expect("regalloc failure");
 
             func.update_from_alloc(result);
             func.print("AFTER", &None);

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -2231,7 +2231,7 @@ impl regalloc::Function for Func {
         &self,
         to_slot: SpillSlot,
         from_reg: RealReg,
-        _for_vreg: VirtualReg,
+        _for_vreg: Option<VirtualReg>,
     ) -> Self::Inst {
         match from_reg.get_class() {
             RegClass::I32 => i_spill(to_slot, from_reg),
@@ -2245,7 +2245,7 @@ impl regalloc::Function for Func {
         &self,
         to_reg: Writable<RealReg>,
         from_slot: SpillSlot,
-        _for_vreg: VirtualReg,
+        _for_vreg: Option<VirtualReg>,
     ) -> Self::Inst {
         match to_reg.to_reg().get_class() {
             RegClass::I32 => i_reload(to_reg.to_reg(), from_slot),

--- a/bin/validator.rs
+++ b/bin/validator.rs
@@ -177,7 +177,17 @@ pub fn validate(func: &Func, real_reg_universe: &RealRegUniverse) -> Result<(), 
         }
     }
 
-    if let Err(err) = regalloc::analysis_main::run_analysis(func, real_reg_universe) {
+    if let Err(err) = regalloc::analysis_main::run_analysis(
+        func,
+        real_reg_universe,
+        // The next four params merely ensure that we get all possible analysis results from
+        // `run_analysis`.  There's no implied claim about which algorithm we're using or
+        // validating.
+        AlgorithmWithDefaults::Backtracking,
+        /*client_wants_stackmaps=*/ true,
+        /*reftype_class=*/ RegClass::I64,
+        /*reftyped_vregs=*/ &vec![],
+    ) {
         return Err(err.to_string());
     }
 

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -49,7 +49,7 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, opts);
+    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, &None, opts);
 
     match ra_result {
         Ok(result) => {

--- a/fuzz/fuzz_bt_differential.rs
+++ b/fuzz/fuzz_bt_differential.rs
@@ -23,7 +23,7 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, opts) {
+    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, &None, opts) {
         Ok(result) => result,
         Err(err) => {
             if let regalloc::RegAllocError::RegChecker(_) = &err {

--- a/fuzz/fuzz_lsra.rs
+++ b/fuzz/fuzz_lsra.rs
@@ -18,6 +18,7 @@ fuzz_target!(|func: ir::Func| {
     let result = match regalloc::allocate_registers(
         &mut func,
         &reg_universe,
+        &None,
         regalloc::AlgorithmWithDefaults::LinearScan,
     ) {
         Ok(result) => result,

--- a/fuzz/fuzz_lsra_differential.rs
+++ b/fuzz/fuzz_lsra_differential.rs
@@ -29,6 +29,7 @@ fuzz_target!(|func: ir::Func| {
     let result = match regalloc::allocate_registers(
         &mut func,
         &reg_universe,
+        &None,
         regalloc::AlgorithmWithDefaults::LinearScan,
     ) {
         Ok(result) => result,

--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -7,10 +7,11 @@ use std::fmt;
 
 use crate::analysis_control_flow::CFGInfo;
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, Point, Queue, RangeFrag, RangeFragIx, RangeFragKind,
-    RangeFragMetrics, RealRange, RealRangeIx, RealReg, RealRegUniverse, Reg, RegClass, RegSets,
-    RegUsageCollector, RegVecBounds, RegVecs, RegVecsAndBounds, SortedRangeFragIxs,
-    SortedRangeFrags, SpillCost, TypedIxVec, VirtualRange, VirtualRangeIx,
+    BlockIx, InstIx, InstPoint, MoveInfo, MoveInfoElem, Point, Queue, RangeFrag, RangeFragIx,
+    RangeFragKind, RangeFragMetrics, RealRange, RealRangeIx, RealReg, RealRegUniverse, Reg,
+    RegClass, RegSets, RegToRangesMaps, RegUsageCollector, RegVecBounds, RegVecs, RegVecsAndBounds,
+    SortedRangeFragIxs, SortedRangeFrags, SpillCost, TypedIxVec, VirtualRange, VirtualRangeIx,
+    VirtualReg,
 };
 use crate::sparse_set::SparseSet;
 use crate::union_find::{ToFromU32, UnionFind};
@@ -1154,9 +1155,7 @@ pub fn get_range_frags<F: Function>(
     assert!(rvb.is_sanitized());
 
     // In order that we can work with unified-reg-indices (see comments above), we need to know
-    // (1) how many virtual regs there are and (2) the `RegClass` for each.  That info is
-    // collected in a single pass here.  In principle regalloc.rs's user could tell us (1), but
-    // as yet the interface does not make that possible.
+    // the `RegClass` for each virtual register.  That info is collected here.
     let mut vreg_classes = vec![RegClass::INVALID; func.get_num_vregs()];
     for r in rvb
         .vecs
@@ -1458,6 +1457,7 @@ fn create_and_add_range(
             vreg: reg.to_virtual_reg(),
             rreg: None,
             sorted_frags,
+            is_ref: false, // analysis_reftypes.rs may later change this
             size,
             total_cost,
             spill_cost,
@@ -1466,6 +1466,7 @@ fn create_and_add_range(
         result_real.push(RealRange {
             rreg: reg.to_real_reg(),
             sorted_frags: sorted_frag_ixs,
+            is_ref: false, // analysis_reftypes.rs may later change this
         });
     }
 }
@@ -1805,4 +1806,119 @@ pub fn merge_range_frags(
     info!("    merge_range_frags: end");
 
     (result_real, result_virtual)
+}
+
+//=============================================================================
+// Auxiliary activities that mostly fall under the category "dataflow analysis", but are not
+// part of the main dataflow analysis pipeline.
+
+// Dataflow and liveness together create vectors of VirtualRanges and RealRanges.  These define
+// (amongst other things) mappings from VirtualRanges to VirtualRegs and from RealRanges to
+// RealRegs.  However, we often need the inverse mappings: from VirtualRegs to (sets of
+// VirtualRanges) and from RealRegs to (sets of) RealRanges.  This function computes those
+// inverse mappings.  They are used by BT's coalescing analysis, and for the dataflow analysis
+// that supports reftype handling.
+#[inline(never)]
+pub fn compute_reg_to_ranges_maps<F: Function>(
+    func: &F,
+    univ: &RealRegUniverse,
+    rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
+    vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
+) -> RegToRangesMaps {
+    // We have in hand the virtual live ranges.  Each of these carries its
+    // associated vreg.  So in effect we have a VLR -> VReg mapping.  We now
+    // invert that, so as to generate a mapping from VRegs to their containing
+    // VLRs.
+    //
+    // Note that multiple VLRs may map to the same VReg.  So the inverse mapping
+    // will actually be from VRegs to a set of VLRs.  In most cases, we expect
+    // the virtual-registerised-code given to this allocator to be derived from
+    // SSA, in which case each VReg will have only one VLR.  So in this case,
+    // the cost of first creating the mapping, and then looking up all the VRegs
+    // in moves in it, will have cost linear in the size of the input function.
+    //
+    // NB re the SmallVec.  That has set semantics (no dups).
+    let mut vreg_to_vlrs_map = vec![SmallVec::<[VirtualRangeIx; 3]>::new(); func.get_num_vregs()];
+    for (vlr, n) in vlr_env.iter().zip(0..) {
+        let vlrix = VirtualRangeIx::new(n);
+        let vreg: VirtualReg = vlr.vreg;
+        // Now we know that there's a VLR `vlr` that is for VReg `vreg`.  Update the inverse
+        // mapping accordingly.  We know we are stepping sequentially through the VLR (index)
+        // space, so we'll never see the same VLRIx twice.  Hence there's no need to check for
+        // dups when adding a VLR index to an existing binding for a VReg.
+        //
+        // If this array-indexing fails, it means the client's `.get_num_vregs()` function
+        // claims there are fewer virtual regs than we actually observe in the code it gave us.
+        // So it's a bug in the client.
+        vreg_to_vlrs_map[vreg.get_index()].push(vlrix);
+    }
+
+    // Same for the real live ranges.
+    let mut rreg_to_rlrs_map = vec![Vec::<RealRangeIx>::new(); univ.allocable];
+    for (rlr, n) in rlr_env.iter().zip(0..) {
+        let rlrix = RealRangeIx::new(n);
+        let rreg: RealReg = rlr.rreg;
+        // If this array-indexing fails, it means something has gone wrong with sanitisation of
+        // real registers -- that should ensure that we never see a real register with an index
+        // greater than `univ.allocable`.  So it's a bug in the allocator's analysis phases.
+        rreg_to_rlrs_map[rreg.get_index()].push(rlrix);
+    }
+
+    RegToRangesMaps {
+        rreg_to_rlrs_map,
+        vreg_to_vlrs_map,
+    }
+}
+
+// Collect info about registers that are connected by moves:
+#[inline(never)]
+pub fn collect_move_info<F: Function>(
+    func: &F,
+    reg_vecs_and_bounds: &RegVecsAndBounds,
+    est_freqs: &TypedIxVec<BlockIx, u32>,
+) -> MoveInfo {
+    let mut moves = Vec::<MoveInfoElem>::new();
+    for b in func.blocks() {
+        let block_eef = est_freqs[b];
+        for iix in func.block_insns(b) {
+            let insn = &func.get_insn(iix);
+            let im = func.is_move(insn);
+            match im {
+                None => {}
+                Some((wreg, reg)) => {
+                    let iix_bounds = &reg_vecs_and_bounds.bounds[iix];
+                    // It might seem strange to assert that `defs_len` and/or
+                    // `uses_len` is <= 1 rather than == 1.  The reason is
+                    // that either or even both registers might be ones which
+                    // are not available to the allocator.  Hence they will
+                    // have been removed by the sanitisation machinery before
+                    // we get to this point.  If either is missing, we
+                    // unfortunately can't coalesce the move away, and just
+                    // have to live with it.
+                    //
+                    // If any of the following five assertions fail, the
+                    // client's `is_move` is probably lying to us.
+                    assert!(iix_bounds.uses_len <= 1);
+                    assert!(iix_bounds.defs_len <= 1);
+                    assert!(iix_bounds.mods_len == 0);
+                    if iix_bounds.uses_len == 1 && iix_bounds.defs_len == 1 {
+                        let reg_vecs = &reg_vecs_and_bounds.vecs;
+                        assert!(reg_vecs.uses[iix_bounds.uses_start as usize] == reg);
+                        assert!(reg_vecs.defs[iix_bounds.defs_start as usize] == wreg.to_reg());
+                        let dst = wreg.to_reg();
+                        let src = reg;
+                        let est_freq = block_eef;
+                        moves.push(MoveInfoElem {
+                            dst,
+                            src,
+                            iix,
+                            est_freq,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    MoveInfo { moves }
 }

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -4,14 +4,17 @@ use log::{debug, info};
 
 use crate::analysis_control_flow::{CFGInfo, InstIxToBlockIxMap};
 use crate::analysis_data_flow::{
-    calc_def_and_use, calc_livein_and_liveout, get_range_frags, get_sanitized_reg_uses_for_func,
-    merge_range_frags,
+    calc_def_and_use, calc_livein_and_liveout, collect_move_info, compute_reg_to_ranges_maps,
+    get_range_frags, get_sanitized_reg_uses_for_func, merge_range_frags,
 };
+use crate::analysis_reftypes::do_reftypes_analysis;
 use crate::data_structures::{
-    BlockIx, RangeFrag, RangeFragIx, RangeFragMetrics, RealRange, RealRangeIx, RealReg,
-    RealRegUniverse, RegVecsAndBounds, TypedIxVec, VirtualRange, VirtualRangeIx,
+    BlockIx, MoveInfo, RangeFrag, RangeFragIx, RangeFragMetrics, RealRange, RealRangeIx, RealReg,
+    RealRegUniverse, RegClass, RegToRangesMaps, RegVecsAndBounds, TypedIxVec, VirtualRange,
+    VirtualRangeIx, VirtualReg,
 };
 use crate::sparse_set::SparseSet;
+use crate::AlgorithmWithDefaults;
 use crate::Function;
 
 //=============================================================================
@@ -45,6 +48,10 @@ pub enum AnalysisError {
     /// Implementation limits exceeded.  The incoming function is too big.  It
     /// may contain at most 1 million basic blocks and 16 million instructions.
     ImplementationLimitsExceeded,
+
+    /// Currently LSRA can't generate stackmaps, but the client has requested LSRA *and*
+    /// stackmaps.
+    LSRACantDoStackmaps,
 }
 
 impl ToString for AnalysisError {
@@ -64,6 +71,9 @@ impl ToString for AnalysisError {
       }
       AnalysisError::ImplementationLimitsExceeded => {
         "implementation limits exceeded (more than 1 million blocks or 16 million insns)".to_string()
+      }
+      AnalysisError::LSRACantDoStackmaps => {
+        "LSRA *and* stackmap creation requested; but this combination is not yet supported".to_string()
       }
     }
     }
@@ -87,12 +97,23 @@ pub struct AnalysisInfo {
     pub(crate) estimated_frequencies: TypedIxVec<BlockIx, u32>,
     /// Maps InstIxs to BlockIxs
     pub(crate) inst_to_block_map: InstIxToBlockIxMap,
+    /// Maps from RealRegs to sets of RealRanges and VirtualRegs to sets of VirtualRanges
+    /// (all operating on indices, not the actual objects).  This is only generated in
+    /// situations where we need it, hence the `Option`.
+    pub(crate) reg_to_ranges_maps: Option<RegToRangesMaps>,
+    /// Information about registers connected by moves.  This is only generated in situations
+    /// where we need it, hence the `Option`.
+    pub(crate) move_info: Option<MoveInfo>,
 }
 
 #[inline(never)]
 pub fn run_analysis<F: Function>(
     func: &F,
     reg_universe: &RealRegUniverse,
+    algorithm: AlgorithmWithDefaults,
+    client_wants_stackmaps: bool,
+    reftype_class: RegClass,
+    reftyped_vregs: &Vec<VirtualReg>, // as supplied by the client
 ) -> Result<AnalysisInfo, AnalysisError> {
     info!("run_analysis: begin");
     info!(
@@ -100,6 +121,12 @@ pub fn run_analysis<F: Function>(
         func.blocks().len(),
         func.insns().len()
     );
+
+    // LSRA can't do reftypes yet.  That should have been checked at the top level already.
+    if client_wants_stackmaps {
+        assert!(algorithm != AlgorithmWithDefaults::LinearScan);
+    }
+
     info!("  run_analysis: begin control flow analysis");
 
     // First do control flow analysis.  This is (relatively) simple.  Note that
@@ -196,7 +223,9 @@ pub fn run_analysis<F: Function>(
         &liveout_sets_per_block,
     );
 
-    let (rlr_env, vlr_env) = merge_range_frags(
+    // These have to be mut because they may get changed below by the call to
+    // `to_reftypes_analysis`.
+    let (mut rlr_env, mut vlr_env) = merge_range_frags(
         &frag_ixs_per_reg,
         &frag_env,
         &frag_metrics_env,
@@ -226,7 +255,48 @@ pub fn run_analysis<F: Function>(
         n += 1;
     }
 
+    // Now a bit of auxiliary info collection, which isn't really either control- or data-flow
+    // analysis.
+
+    // For BT and/or reftypes, we'll also need the reg-to-ranges maps.
+    let reg_to_ranges_maps =
+        if client_wants_stackmaps || algorithm == AlgorithmWithDefaults::Backtracking {
+            Some(compute_reg_to_ranges_maps(
+                func,
+                &reg_universe,
+                &rlr_env,
+                &vlr_env,
+            ))
+        } else {
+            None
+        };
+
+    // For BT and/or reftypes, we'll also need information about moves.
+    let move_info = if client_wants_stackmaps || algorithm == AlgorithmWithDefaults::Backtracking {
+        Some(collect_move_info(
+            func,
+            &reg_vecs_and_bounds,
+            &estimated_frequencies,
+        ))
+    } else {
+        None
+    };
+
     info!("  run_analysis: end liveness analysis");
+
+    if client_wants_stackmaps {
+        info!("  run_analysis: begin reftypes analysis");
+        do_reftypes_analysis(
+            &mut rlr_env,
+            &mut vlr_env,
+            reg_to_ranges_maps.as_ref().unwrap(), /* safe because of logic just above */
+            &move_info.as_ref().unwrap(),         /* ditto */
+            reftype_class,
+            reftyped_vregs,
+        );
+        info!("  run_analysis: end reftypes analysis");
+    }
+
     info!("run_analysis: end");
 
     Ok(AnalysisInfo {
@@ -237,5 +307,7 @@ pub fn run_analysis<F: Function>(
         range_metrics: frag_metrics_env,
         estimated_frequencies,
         inst_to_block_map,
+        reg_to_ranges_maps,
+        move_info,
     })
 }

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -1,0 +1,142 @@
+//! Performs a simple taint analysis, to find all live ranges that are reftyped.
+
+use crate::data_structures::{
+    MoveInfo, MoveInfoElem, RangeId, RealRange, RealRangeIx, RegClass, RegToRangesMaps, TypedIxVec,
+    VirtualRange, VirtualRangeIx, VirtualReg,
+};
+use crate::sparse_set::SparseSet;
+
+pub fn do_reftypes_analysis(
+    // From dataflow/liveness analysis.  Modified by setting their is_ref bit.
+    rlr_env: &mut TypedIxVec<RealRangeIx, RealRange>,
+    vlr_env: &mut TypedIxVec<VirtualRangeIx, VirtualRange>,
+    // From dataflow analysis
+    reg_to_ranges_maps: &RegToRangesMaps,
+    move_info: &MoveInfo,
+    // As supplied by the client
+    reftype_class: RegClass,
+    reftyped_vregs: &Vec<VirtualReg>,
+) {
+    // The game here is: starting with `reftyped_vregs`, find *all* the VirtualRanges and
+    // RealRanges to which that refness can flow, via instructions which the client's `is_move`
+    // function considers to be moves.
+
+    // We have `move_info`, which tells us which regs (both real and virtual) are connected by
+    // moves.  However, that's not directly useful -- we need to know which *ranges* are
+    // connected by moves.  So first, convert `move_info` into a set of range-pairs.
+
+    let mut range_pairs = Vec::<(RangeId, RangeId)>::new(); // (DST, SRC)
+
+    for MoveInfoElem {
+        dst: dst_reg,
+        src: src_reg,
+        iix: _,
+        est_freq: _,
+    } in &move_info.moves
+    {
+        debug_assert!(dst_reg.get_class() == src_reg.get_class());
+
+        // Don't waste time processing moves which can't possibly be of reftyped values.
+        if dst_reg.get_class() != reftype_class {
+            continue;
+        }
+
+        // This is kinda tiresome because of the differing representations, but .. construct the
+        // cartesian product of the range indicies for both the source and destination of the
+        // move.
+
+        let dst_reg_ix = dst_reg.get_index();
+        let src_reg_ix = src_reg.get_index();
+        match (dst_reg.is_real(), src_reg.is_real()) {
+            (true, true) => {
+                // R <- R
+                for dst_ix in &reg_to_ranges_maps.rreg_to_rlrs_map[dst_reg_ix] {
+                    for src_ix in &reg_to_ranges_maps.rreg_to_rlrs_map[src_reg_ix] {
+                        range_pairs.push((RangeId::new_real(*dst_ix), RangeId::new_real(*src_ix)));
+                    }
+                }
+            }
+            (true, false) => {
+                // R <- V
+                for dst_ix in &reg_to_ranges_maps.rreg_to_rlrs_map[dst_reg_ix] {
+                    for src_ix in &reg_to_ranges_maps.vreg_to_vlrs_map[src_reg_ix] {
+                        range_pairs
+                            .push((RangeId::new_real(*dst_ix), RangeId::new_virtual(*src_ix)));
+                    }
+                }
+            }
+            (false, true) => {
+                // V <- R
+                for dst_ix in &reg_to_ranges_maps.vreg_to_vlrs_map[dst_reg_ix] {
+                    for src_ix in &reg_to_ranges_maps.rreg_to_rlrs_map[src_reg_ix] {
+                        range_pairs
+                            .push((RangeId::new_virtual(*dst_ix), RangeId::new_real(*src_ix)));
+                    }
+                }
+            }
+            (false, false) => {
+                // V <- V
+                for dst_ix in &reg_to_ranges_maps.vreg_to_vlrs_map[dst_reg_ix] {
+                    for src_ix in &reg_to_ranges_maps.vreg_to_vlrs_map[src_reg_ix] {
+                        range_pairs
+                            .push((RangeId::new_virtual(*dst_ix), RangeId::new_virtual(*src_ix)));
+                    }
+                }
+            }
+        }
+    }
+
+    // We have to hand the range-pairs that must be a superset of the moves that could possibly
+    // carry reftyped values.  Now compute the starting set of reftyped virtual ranges.  This
+    // can serve as the starting value for the following fixpoint iteration.
+
+    let mut reftyped_ranges = SparseSet::<RangeId>::empty();
+    for vreg in reftyped_vregs {
+        // If this fails, the client has been telling is that some virtual reg is reftyped, yet
+        // it doesn't belong to the class of regs that it claims can carry refs.  So the client
+        // is buggy.
+        debug_assert!(vreg.get_class() == reftype_class);
+        for vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()] {
+            reftyped_ranges.insert(RangeId::new_virtual(*vlrix));
+        }
+    }
+
+    // Now, finally, compute the fixpoint resulting from repeatedly mapping `reftyped_ranges`
+    // through `range_pairs`. XXXX this looks dangerously expensive .. reimplement.
+    //
+    // Later .. this is overkill.  All that is needed is a DFS of the directed graph in which
+    // the nodes are the union of the RealRange(Ixs) and the VirtualRange(Ixs), and whose edges
+    // are exactly what we computed into `range_pairs`.  This graph then needs to be searched
+    // from each root in `reftyped_ranges`.
+    loop {
+        let card_before = reftyped_ranges.card();
+
+        for (dst_lr_id, src_lr_id) in &range_pairs {
+            if reftyped_ranges.contains(*src_lr_id) {
+                reftyped_ranges.insert(*dst_lr_id);
+            }
+        }
+
+        let card_after = reftyped_ranges.card();
+        if card_after == card_before {
+            // Since we're only ever adding items to `reftyped_ranges`, and it has set
+            // semantics, checking that the cardinality is unchanged is an adequate check for
+            // having reached a (the minimal?) fixpoint.
+            break;
+        }
+    }
+
+    // Finally, annotate rlr_env/vlr_env with the results of the analysis.  (That was the whole
+    // point!)
+    for lr_id in reftyped_ranges.iter() {
+        if lr_id.is_real() {
+            let rrange = &mut rlr_env[lr_id.to_real()];
+            debug_assert!(!rrange.is_ref);
+            rrange.is_ref = true;
+        } else {
+            let vrange = &mut vlr_env[lr_id.to_virtual()];
+            debug_assert!(!vrange.is_ref);
+            vrange.is_ref = true;
+        }
+    }
+}

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -30,8 +30,8 @@ use log::{debug, info, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
 
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, RangeFrag, RangeFragIx, RealRange, RealRangeIx, RealReg,
-    RealRegUniverse, Reg, RegVecsAndBounds, SpillCost, TypedIxVec, VirtualRange, VirtualRangeIx,
+    InstIx, InstPoint, MoveInfo, MoveInfoElem, RangeFrag, RangeFragIx, RealRange, RealRangeIx,
+    RealReg, RealRegUniverse, RegToRangesMaps, SpillCost, TypedIxVec, VirtualRange, VirtualRangeIx,
     VirtualReg,
 };
 use crate::union_find::{ToFromU32, UnionFind, UnionFindEquivClasses};
@@ -132,197 +132,113 @@ impl ToFromU32 for VirtualRangeIx {
 #[inline(never)]
 pub fn do_coalescing_analysis<F: Function>(
     func: &F,
-    reg_vecs_and_bounds: &RegVecsAndBounds,
+    univ: &RealRegUniverse,
     rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
     vlr_env: &mut TypedIxVec<VirtualRangeIx, VirtualRange>,
     frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
-    est_freqs: &TypedIxVec<BlockIx, u32>,
-    univ: &RealRegUniverse,
+    reg_to_ranges_maps: &RegToRangesMaps,
+    move_info: &MoveInfo,
 ) -> (
     TypedIxVec<VirtualRangeIx, SmallVec<[Hint; 8]>>,
     UnionFindEquivClasses<VirtualRangeIx>,
     TypedIxVec<InstIx, bool>,
-    Vec</*vreg index,*/ SmallVec<[VirtualRangeIx; 3]>>,
 ) {
     info!("");
     info!("do_coalescing_analysis: begin");
-    // We have in hand the virtual live ranges.  Each of these carries its
-    // associated vreg.  So in effect we have a VLR -> VReg mapping.  We now
-    // invert that, so as to generate a mapping from VRegs to their containing
-    // VLRs.
-    //
-    // Note that multiple VLRs may map to the same VReg.  So the inverse mapping
-    // will actually be from VRegs to a set of VLRs.  In most cases, we expect
-    // the virtual-registerised-code given to this allocator to be derived from
-    // SSA, in which case each VReg will have only one VLR.  So in this case,
-    // the cost of first creating the mapping, and then looking up all the VRegs
-    // in moves in it, will have cost linear in the size of the input function.
-    //
-    // It would be convenient here to know how many VRegs there are ahead of
-    // time, but until then we'll discover it dynamically.
-    // NB re the SmallVec.  That has set semantics (no dups)
-    // FIXME use SmallVec for the VirtualRangeIxs.  Or even a sparse set.
-    let mut vreg_to_vlrs_map = Vec::</*vreg index,*/ SmallVec<[VirtualRangeIx; 3]>>::new();
 
-    for (vlr, n) in vlr_env.iter().zip(0..) {
-        let vlrix = VirtualRangeIx::new(n);
-        let vreg: VirtualReg = vlr.vreg;
-        // Now we know that there's a VLR `vlr` that is for VReg `vreg`.  Update
-        // the inverse mapping accordingly.  That may involve resizing it, since
-        // we have no idea of the order in which we will first encounter VRegs.
-        // By contrast, we know we are stepping sequentially through the VLR
-        // (index) space, and we'll never see the same VLRIx twice.  So there's no
-        // need to check for dups when adding a VLR index to an existing binding
-        // for a VReg.
-        let vreg_ix = vreg.get_index();
+    // There follow four closures, which are used to find out whether a real or virtual reg has
+    // a last use or first def at some instruction.  This is the central activity of the
+    // coalescing analysis -- finding move instructions that are the last def for the src reg
+    // and the first def for the dst reg.
 
-        while vreg_to_vlrs_map.len() <= vreg_ix {
-            vreg_to_vlrs_map.push(smallvec![]); // This is very un-clever
-        }
-
-        vreg_to_vlrs_map[vreg_ix].push(vlrix);
-    }
-
-    // Same for the real live ranges
-    let mut rreg_to_rlrs_map = Vec::</*rreg index,*/ Vec<RealRangeIx>>::new();
-
-    for (rlr, n) in rlr_env.iter().zip(0..) {
-        let rlrix = RealRangeIx::new(n);
-        let rreg: RealReg = rlr.rreg;
-        let rreg_ix = rreg.get_index();
-
-        while rreg_to_rlrs_map.len() <= rreg_ix {
-            rreg_to_rlrs_map.push(vec![]); // This is very un-clever
-        }
-
-        rreg_to_rlrs_map[rreg_ix].push(rlrix);
-    }
-
-    // And what do we got?
-    //for (vlrixs, vreg) in vreg_to_vlrs_map.iter().zip(0..) {
-    //  println!("QQQQ vreg v{:?} -> vlrixs {:?}", vreg, vlrixs);
-    //}
-    //for (rlrixs, rreg) in rreg_to_rlrs_map.iter().zip(0..) {
-    //  println!("QQQQ rreg r{:?} -> rlrixs {:?}", rreg, rlrixs);
-    //}
-
-    // Range end checks for VRegs.  The XX means either "Last use" or "First
-    // def", depending on the boolean parameter.
-    let doesVRegHaveXXat
-    // `xxIsLastUse` is true means "XX is last use"
-    // `xxIsLastUse` is false means "XX is first def"
-    = |xxIsLastUse: bool, vreg: VirtualReg, iix: InstIx|
-    -> Option<VirtualRangeIx> {
-      let vreg_no = vreg.get_index();
-      let vlrixs = &vreg_to_vlrs_map[vreg_no];
-      for vlrix in vlrixs {
-        for frag in &vlr_env[*vlrix].sorted_frags.frags {
-          if xxIsLastUse {
-            // We're checking to see if `vreg` has a last use in this block
-            // (well, technically, a fragment end in the block; we don't care if
-            // it is later redefined in the same block) .. anyway ..
-            // We're checking to see if `vreg` has a last use in this block
-            // at `iix`.u
-            if frag.last == InstPoint::new_use(iix) {
-              return Some(*vlrix);
-            }
-          } else {
-            // We're checking to see if `vreg` has a first def in this block
-            // at `iix`.d
-            if frag.first == InstPoint::new_def(iix) {
-              return Some(*vlrix);
-            }
-          }
-        }
-      }
-      None
-    };
-
-    // Range end checks for RRegs.  XX has same meaning as above.
-    let doesRRegHaveXXat
-    // `xxIsLastUse` is true means "XX is last use"
-    // `xxIsLastUse` is false means "XX is first def"
-    = |xxIsLastUse: bool, rreg: RealReg, iix: InstIx|
-    -> Option<RealRangeIx> {
-      let rreg_no = rreg.get_index();
-      let rlrixs = &rreg_to_rlrs_map[rreg_no];
-      for rlrix in rlrixs {
-        let frags = &rlr_env[*rlrix].sorted_frags;
-        for fix in &frags.frag_ixs {
-          let frag = &frag_env[*fix];
-          if xxIsLastUse {
-            // We're checking to see if `rreg` has a last use in this block
-            // at `iix`.u
-            if frag.last == InstPoint::new_use(iix) {
-              return Some(*rlrix);
-            }
-          } else {
-            // We're checking to see if `rreg` has a first def in this block
-            // at `iix`.d
-            if frag.first == InstPoint::new_def(iix) {
-              return Some(*rlrix);
-            }
-          }
-        }
-      }
-      None
-    };
-
-    // Make up a vector of registers that are connected by moves:
-    //
-    //    (dstReg, srcReg, transferring insn, estimated execution count of the
-    //                                        containing block)
-    //
-    // This can contain real-to-real moves, which we obviously can't do anything
-    // about.  We'll remove them in the next pass.
-    let mut connectedByMoves = Vec::<(Reg, Reg, InstIx, u32)>::new();
-    for b in func.blocks() {
-        let block_eef = est_freqs[b];
-        for iix in func.block_insns(b) {
-            let insn = &func.get_insn(iix);
-            let im = func.is_move(insn);
-            match im {
-                None => {}
-                Some((wreg, reg)) => {
-                    let iix_bounds = &reg_vecs_and_bounds.bounds[iix];
-                    // It might seem strange to assert that `defs_len` and/or
-                    // `uses_len` is <= 1 rather than == 1.  The reason is
-                    // that either or even both registers might be ones which
-                    // are not available to the allocator.  Hence they will
-                    // have been removed by the sanitisation machinery before
-                    // we get to this point.  If either is missing, we
-                    // unfortunately can't coalesce the move away, and just
-                    // have to live with it.
-                    //
-                    // If any of the following five assertions fail, the
-                    // client's `is_move` is probably lying to us.
-                    assert!(iix_bounds.uses_len <= 1);
-                    assert!(iix_bounds.defs_len <= 1);
-                    assert!(iix_bounds.mods_len == 0);
-                    if iix_bounds.uses_len == 1 && iix_bounds.defs_len == 1 {
-                        let reg_vecs = &reg_vecs_and_bounds.vecs;
-                        assert!(reg_vecs.uses[iix_bounds.uses_start as usize] == reg);
-                        assert!(reg_vecs.defs[iix_bounds.defs_start as usize] == wreg.to_reg());
-                        connectedByMoves.push((wreg.to_reg(), reg, iix, block_eef));
-                    }
+    // Range checks for VRegs -- last use.
+    let doesVRegHaveLastUseAt = |vreg: VirtualReg, iix: InstIx| -> Option<VirtualRangeIx> {
+        let vreg_no = vreg.get_index();
+        let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
+        for vlrix in vlrixs {
+            for frag in &vlr_env[*vlrix].sorted_frags.frags {
+                // We're checking to see if `vreg` has a last use in this block
+                // (well, technically, a fragment end in the block; we don't care if
+                // it is later redefined in the same block) .. anyway ..
+                // We're checking to see if `vreg` has a last use in this block
+                // at `iix`.u
+                if frag.last == InstPoint::new_use(iix) {
+                    return Some(*vlrix);
                 }
             }
         }
-    }
+        None
+    };
 
-    // XX these sub-vectors could contain duplicates, I suppose, for example if
-    // there are two identical copy insns at different points on the "boundary"
-    // for some VLR.  I don't think it matters though since we're going to rank
-    // the hints by strength and then choose at most one.
+    // Range checks for VRegs -- first def.
+    let doesVRegHaveFirstDefAt = |vreg: VirtualReg, iix: InstIx| -> Option<VirtualRangeIx> {
+        let vreg_no = vreg.get_index();
+        let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
+        for vlrix in vlrixs {
+            for frag in &vlr_env[*vlrix].sorted_frags.frags {
+                // We're checking to see if `vreg` has a first def in this block at `iix`.d
+                if frag.first == InstPoint::new_def(iix) {
+                    return Some(*vlrix);
+                }
+            }
+        }
+        None
+    };
+
+    // Range checks for RRegs -- last use.
+    let doesRRegHaveLastUseAt = |rreg: RealReg, iix: InstIx| -> Option<RealRangeIx> {
+        let rreg_no = rreg.get_index();
+        let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
+        for rlrix in rlrixs {
+            let frags = &rlr_env[*rlrix].sorted_frags;
+            for fix in &frags.frag_ixs {
+                let frag = &frag_env[*fix];
+                // We're checking to see if `rreg` has a last use in this block at `iix`.u
+                if frag.last == InstPoint::new_use(iix) {
+                    return Some(*rlrix);
+                }
+            }
+        }
+        None
+    };
+
+    // Range checks for RRegs -- first def.
+    let doesRRegHaveFirstDefAt = |rreg: RealReg, iix: InstIx| -> Option<RealRangeIx> {
+        let rreg_no = rreg.get_index();
+        let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
+        for rlrix in rlrixs {
+            let frags = &rlr_env[*rlrix].sorted_frags;
+            for fix in &frags.frag_ixs {
+                let frag = &frag_env[*fix];
+                // We're checking to see if `rreg` has a first def in this block at `iix`.d
+                if frag.first == InstPoint::new_def(iix) {
+                    return Some(*rlrix);
+                }
+            }
+        }
+        None
+    };
+
+    // RETURNED TO CALLER
+    // Hints for each VirtualRange.  Note that the SmallVecs could contain duplicates, I
+    // suppose, for example if there are two identical copy insns at different points on the
+    // "boundary" for some VLR.  I don't think it matters though since we're going to rank the
+    // hints by strength and then choose at most one.
     let mut hints = TypedIxVec::<VirtualRangeIx, SmallVec<[Hint; 8]>>::new();
     hints.resize(vlr_env.len(), smallvec![]);
 
+    // RETURNED TO CALLER
+    // A vector that simply records which insns are v-to-v boundary moves, as established by the
+    // analysis below.  This info is collected here because (1) the caller (BT) needs to have it
+    // and (2) this is the first point at which we can efficiently compute it.
     let mut is_vv_boundary_move = TypedIxVec::<InstIx, bool>::new();
     is_vv_boundary_move.resize(func.insns().len() as u32, false);
 
+    // RETURNED TO CALLER (after finalisation)
     // The virtual-to-virtual equivalence classes we're collecting.
     let mut vlrEquivClassesUF = UnionFind::<VirtualRangeIx>::new(vlr_env.len() as usize);
 
+    // Not returned to caller; for use only in this function.
     // A list of `VirtualRange`s for which the `total_cost` (hence also their
     // `spill_cost`) should be adjusted downwards by the supplied `u32`.  We
     // can't do this directly in the loop below due to borrowing constraints,
@@ -330,18 +246,24 @@ pub fn do_coalescing_analysis<F: Function>(
     // loop.
     let mut decVLRcosts = Vec::<(VirtualRangeIx, VirtualRangeIx, u32)>::new();
 
-    for (rDst, rSrc, iix, block_eef) in connectedByMoves {
+    for MoveInfoElem {
+        dst,
+        src,
+        iix,
+        est_freq,
+    } in &move_info.moves
+    {
         debug!(
-            "QQQQ connectedByMoves {:?} {:?} <- {:?} (block_eef {})",
-            iix, rDst, rSrc, block_eef
+            "connected by moves: {:?} {:?} <- {:?} (est_freq {})",
+            iix, dst, src, est_freq
         );
-        match (rDst.is_virtual(), rSrc.is_virtual()) {
+        match (dst.is_virtual(), src.is_virtual()) {
             (true, true) => {
                 // Check for a V <- V hint.
-                let rSrcV = rSrc.to_virtual_reg();
-                let rDstV = rDst.to_virtual_reg();
-                let mb_vlrixSrc = doesVRegHaveXXat(/*xxIsLastUse=*/ true, rSrcV, iix);
-                let mb_vlrixDst = doesVRegHaveXXat(/*xxIsLastUse=*/ false, rDstV, iix);
+                let srcV = src.to_virtual_reg();
+                let dstV = dst.to_virtual_reg();
+                let mb_vlrixSrc = doesVRegHaveLastUseAt(srcV, *iix);
+                let mb_vlrixDst = doesVRegHaveFirstDefAt(dstV, *iix);
                 if mb_vlrixSrc.is_some() && mb_vlrixDst.is_some() {
                     let vlrixSrc = mb_vlrixSrc.unwrap();
                     let vlrixDst = mb_vlrixDst.unwrap();
@@ -353,39 +275,39 @@ pub fn do_coalescing_analysis<F: Function>(
                         // Add hints for both VLRs, since we don't know which one will
                         // assign first.  Indeed, a VLR may be assigned and un-assigned
                         // arbitrarily many times.
-                        hints[vlrixSrc].push(Hint::SameAs(vlrixDst, block_eef));
-                        hints[vlrixDst].push(Hint::SameAs(vlrixSrc, block_eef));
+                        hints[vlrixSrc].push(Hint::SameAs(vlrixDst, *est_freq));
+                        hints[vlrixDst].push(Hint::SameAs(vlrixSrc, *est_freq));
                         vlrEquivClassesUF.union(vlrixDst, vlrixSrc);
-                        is_vv_boundary_move[iix] = true;
+                        is_vv_boundary_move[*iix] = true;
                         // Reduce the total cost, and hence the spill cost, of
                         // both `vlrixSrc` and `vlrixDst`.  This is so as to reduce to
                         // zero, the cost of a VLR whose only instructions are its
                         // v-v boundary copies.
-                        debug!("QQQQ reduce cost of {:?} and {:?}", vlrixSrc, vlrixDst);
-                        decVLRcosts.push((vlrixSrc, vlrixDst, 1 * block_eef));
+                        debug!("reduce cost of {:?} and {:?}", vlrixSrc, vlrixDst);
+                        decVLRcosts.push((vlrixSrc, vlrixDst, 1 * est_freq));
                     }
                 }
             }
             (true, false) => {
                 // Check for a V <- R hint.
-                let rSrcR = rSrc.to_real_reg();
-                let rDstV = rDst.to_virtual_reg();
-                let mb_rlrSrc = doesRRegHaveXXat(/*xxIsLastUse=*/ true, rSrcR, iix);
-                let mb_vlrDst = doesVRegHaveXXat(/*xxIsLastUse=*/ false, rDstV, iix);
+                let srcR = src.to_real_reg();
+                let dstV = dst.to_virtual_reg();
+                let mb_rlrSrc = doesRRegHaveLastUseAt(srcR, *iix);
+                let mb_vlrDst = doesVRegHaveFirstDefAt(dstV, *iix);
                 if mb_rlrSrc.is_some() && mb_vlrDst.is_some() {
                     let vlrDst = mb_vlrDst.unwrap();
-                    hints[vlrDst].push(Hint::Exactly(rSrcR, block_eef));
+                    hints[vlrDst].push(Hint::Exactly(srcR, *est_freq));
                 }
             }
             (false, true) => {
                 // Check for a R <- V hint.
-                let rSrcV = rSrc.to_virtual_reg();
-                let rDstR = rDst.to_real_reg();
-                let mb_vlrSrc = doesVRegHaveXXat(/*xxIsLastUse=*/ true, rSrcV, iix);
-                let mb_rlrDst = doesRRegHaveXXat(/*xxIsLastUse=*/ false, rDstR, iix);
+                let srcV = src.to_virtual_reg();
+                let dstR = dst.to_real_reg();
+                let mb_vlrSrc = doesVRegHaveLastUseAt(srcV, *iix);
+                let mb_rlrDst = doesRRegHaveFirstDefAt(dstR, *iix);
                 if mb_vlrSrc.is_some() && mb_rlrDst.is_some() {
                     let vlrSrc = mb_vlrSrc.unwrap();
-                    hints[vlrSrc].push(Hint::Exactly(rDstR, block_eef));
+                    hints[vlrSrc].push(Hint::Exactly(dstR, *est_freq));
                 }
             }
             (false, false) => {
@@ -468,10 +390,5 @@ pub fn do_coalescing_analysis<F: Function>(
     info!("do_coalescing_analysis: end");
     info!("");
 
-    (
-        hints,
-        vlrEquivClasses,
-        is_vv_boundary_move,
-        vreg_to_vlrs_map,
-    )
+    (hints, vlrEquivClasses, is_vv_boundary_move)
 }

--- a/lib/src/bt_commitment_map.rs
+++ b/lib/src/bt_commitment_map.rs
@@ -6,61 +6,62 @@
 use std::cmp::Ordering;
 use std::fmt;
 
-use crate::avl_tree::AVLTree;
+use crate::avl_tree::{AVLTree, AVL_NULL};
 use crate::data_structures::{
-    cmp_range_frags, RangeFrag, RangeFragIx, SortedRangeFragIxs, SortedRangeFrags, TypedIxVec,
-    VirtualRangeIx,
+    cmp_range_frags, InstPoint, RangeFrag, RangeFragIx, RangeId, SortedRangeFragIxs,
+    SortedRangeFrags, TypedIxVec,
 };
 
 //=============================================================================
 // Per-real-register commitment maps
 //
 
-// Something that pairs a fragment index with the index of the virtual range
-// to which this fragment conceptually "belongs", at least for the purposes of
-// this commitment map.  Alternatively, the `vlrix` field may be None, which
-// indicates that the associated fragment belongs to a real-reg live range and
-// is therefore non-evictable.
+// Something that pairs a fragment index with the identity of the virtual or real range to which
+// this fragment conceptually "belongs", at least for the purposes of this commitment map.  If
+// the `lr_id` field denotes a real range, the associated fragment belongs to a real-reg live
+// range and is therefore non-evictable.  The identity of the range is necessary because:
 //
-// (A fragment merely denotes a sequence of instruction (points), but within
-// the context of a commitment map for a real register, obviously any
-// particular fragment can't be part of two different virtual live ranges.)
+// * for VirtualRanges, (1) we may need to evict the mapping, so we will need to get hold of the
+//   VirtualRange, so that we have all fragments of the VirtualRange to hand, and (2) if the
+//   client requires stackmaps, we need to look at the VirtualRange to see if it is reftyped.
 //
-// Note that we don't intend to actually use the PartialOrd methods for
-// FIxAndVLRix.  However, they need to exist since we want to construct an
-// AVLTree<FIxAndVLRix>, and that requires PartialOrd for its element type.
-// For working with such trees we will supply our own comparison function;
-// hence PartialOrd here serves only to placate the typechecker.  It should
-// never actually be used.
+// * for RealRanges, only (2) applies; (1) is irrelevant since RealRange assignments are
+//   non-evictable.
+//
+// (A fragment merely denotes a sequence of instruction (points), but within the context of a
+// commitment map for a real register, obviously any particular fragment can't be part of two
+// different virtual live ranges.)
+//
+// Note that we don't intend to actually use the PartialOrd methods for RangeFragAndRangeId.
+// However, they need to exist since we want to construct an AVLTree<RangeFragAndRangeId>, and
+// that requires PartialOrd for its element type.  For working with such trees we will supply
+// our own comparison function; hence PartialOrd here serves only to placate the typechecker.
+// It should never actually be used.
 #[derive(Clone)]
-pub struct RangeFragAndVLRIx {
+pub struct RangeFragAndRangeId {
     pub frag: RangeFrag,
-    pub mb_vlrix: Option<VirtualRangeIx>,
+    pub id: RangeId,
 }
-impl RangeFragAndVLRIx {
-    fn new(frag: RangeFrag, mb_vlrix: Option<VirtualRangeIx>) -> Self {
-        Self { frag, mb_vlrix }
+impl RangeFragAndRangeId {
+    fn new(frag: RangeFrag, id: RangeId) -> Self {
+        Self { frag, id }
     }
 }
-impl PartialEq for RangeFragAndVLRIx {
+impl PartialEq for RangeFragAndRangeId {
     fn eq(&self, _other: &Self) -> bool {
         // See comments above.
-        panic!("impl PartialEq for RangeFragAndVLRIx: should never be used");
+        panic!("impl PartialEq for RangeFragAndRangeId: should never be used");
     }
 }
-impl PartialOrd for RangeFragAndVLRIx {
+impl PartialOrd for RangeFragAndRangeId {
     fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
         // See comments above.
-        panic!("impl PartialOrd for RangeFragAndVLRIx: should never be used");
+        panic!("impl PartialOrd for RangeFragAndRangeId: should never be used");
     }
 }
-impl fmt::Debug for RangeFragAndVLRIx {
+impl fmt::Debug for RangeFragAndRangeId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let vlrix_string = match self.mb_vlrix {
-            None => "NONE".to_string(),
-            Some(vlrix) => format!("{:?}", vlrix),
-        };
-        write!(fmt, "(FnV {:?} {})", self.frag, vlrix_string)
+        write!(fmt, "(FnV {:?} {:?})", self.frag, self.id)
     }
 }
 
@@ -70,13 +71,10 @@ impl fmt::Debug for RangeFragAndVLRIx {
 
 // This indicates the current set of fragments to which some real register is
 // currently "committed".  The fragments *must* be non-overlapping.  Hence
-// they form a total order, and so they must appear in the vector sorted by
-// that order.
-//
-// Overall this is identical to SortedRangeFragIxs, except extended so that
-// each FragIx is tagged with an Option<VirtualRangeIx>.
+// they form a total order, and so we may validly build an AVL tree of them.
+
 pub struct CommitmentMap {
-    pub tree: AVLTree<RangeFragAndVLRIx>,
+    pub tree: AVLTree<RangeFragAndRangeId>,
 }
 impl fmt::Debug for CommitmentMap {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -88,27 +86,20 @@ impl fmt::Debug for CommitmentMap {
 impl CommitmentMap {
     pub fn new() -> Self {
         // The AVL tree constructor needs a default value for the elements.  It
-        // will never be used.  The not-present index value will show as
+        // will never be used.  The RangeId index value will show as
         // obviously bogus if we ever try to "dereference" any part of it.
-        let dflt = RangeFragAndVLRIx::new(
-            RangeFrag::invalid_value(),
-            Some(VirtualRangeIx::invalid_value()),
-        );
+        let dflt = RangeFragAndRangeId::new(RangeFrag::invalid_value(), RangeId::invalid_value());
         Self {
-            tree: AVLTree::<RangeFragAndVLRIx>::new(dflt),
+            tree: AVLTree::<RangeFragAndRangeId>::new(dflt),
         }
     }
 
-    pub fn add(
-        &mut self,
-        to_add_frags: &SortedRangeFrags,
-        to_add_mb_vlrix: Option<VirtualRangeIx>,
-    ) {
+    pub fn add(&mut self, to_add_frags: &SortedRangeFrags, to_add_lr_id: RangeId) {
         for frag in &to_add_frags.frags {
-            let to_add = RangeFragAndVLRIx::new(frag.clone(), to_add_mb_vlrix);
+            let to_add = RangeFragAndRangeId::new(frag.clone(), to_add_lr_id);
             let added = self.tree.insert(
                 to_add,
-                Some(&|pair1: RangeFragAndVLRIx, pair2: RangeFragAndVLRIx| {
+                Some(&|pair1: RangeFragAndRangeId, pair2: RangeFragAndRangeId| {
                     cmp_range_frags(&pair1.frag, &pair2.frag)
                 }),
             );
@@ -121,14 +112,14 @@ impl CommitmentMap {
     pub fn add_indirect(
         &mut self,
         to_add_frags: &SortedRangeFragIxs,
-        to_add_mb_vlrix: Option<VirtualRangeIx>,
+        to_add_lr_id: RangeId,
         frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
     ) {
         for fix in &to_add_frags.frag_ixs {
-            let to_add = RangeFragAndVLRIx::new(frag_env[*fix].clone(), to_add_mb_vlrix);
+            let to_add = RangeFragAndRangeId::new(frag_env[*fix].clone(), to_add_lr_id);
             let added = self.tree.insert(
                 to_add,
-                Some(&|pair1: RangeFragAndVLRIx, pair2: RangeFragAndVLRIx| {
+                Some(&|pair1: RangeFragAndRangeId, pair2: RangeFragAndRangeId| {
                     cmp_range_frags(&pair1.frag, &pair2.frag)
                 }),
             );
@@ -140,12 +131,12 @@ impl CommitmentMap {
 
     pub fn del(&mut self, to_del_frags: &SortedRangeFrags) {
         for frag in &to_del_frags.frags {
-            // re None: we don't care what the VLRIx is, since we're deleting by
-            // RangeFrags alone.
-            let to_del = RangeFragAndVLRIx::new(frag.clone(), None);
+            // re RangeId::invalid_value(): we don't care what the RangeId is, since we're
+            // deleting by RangeFrags alone.
+            let to_del = RangeFragAndRangeId::new(frag.clone(), RangeId::invalid_value());
             let deleted = self.tree.delete(
                 to_del,
-                Some(&|pair1: RangeFragAndVLRIx, pair2: RangeFragAndVLRIx| {
+                Some(&|pair1: RangeFragAndRangeId, pair2: RangeFragAndRangeId| {
                     cmp_range_frags(&pair1.frag, &pair2.frag)
                 }),
             );
@@ -153,5 +144,27 @@ impl CommitmentMap {
             // That's also a serious error.
             assert!(deleted);
         }
+    }
+
+    // Find the RangeId for the RangeFrag that overlaps `pt`, if one exists.
+    // This is conceptually equivalent to LogicalSpillSlot::get_refness_at_inst_point.
+    pub fn lookup_inst_point(&self, pt: InstPoint) -> Option<RangeId> {
+        let mut root = self.tree.root;
+        while root != AVL_NULL {
+            let root_node = &self.tree.pool[root as usize];
+            let root_item = &root_node.item;
+            if pt < root_item.frag.first {
+                // `pt` is to the left of the `root`.  So there's no
+                // overlap with `root`.  Continue by inspecting the left subtree.
+                root = root_node.left;
+            } else if root_item.frag.last < pt {
+                // Ditto for the right subtree.
+                root = root_node.right;
+            } else {
+                // `pt` overlaps the `root`, so we have what we want.
+                return Some(root_item.id);
+            }
+        }
+        None
     }
 }

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -12,18 +12,21 @@ use crate::analysis_data_flow::{add_raw_reg_vecs_for_insn, does_inst_use_def_or_
 use crate::analysis_main::{run_analysis, AnalysisInfo};
 use crate::avl_tree::{AVLTree, AVL_NULL};
 use crate::bt_coalescing_analysis::{do_coalescing_analysis, Hint};
-use crate::bt_commitment_map::{CommitmentMap, RangeFragAndVLRIx};
+use crate::bt_commitment_map::{CommitmentMap, RangeFragAndRangeId};
 use crate::bt_spillslot_allocator::SpillSlotAllocator;
 use crate::bt_vlr_priority_queue::VirtualRangePrioQ;
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, Point, RangeFrag, RangeFragIx, RealRange, RealReg, RealRegUniverse,
-    Reg, RegVecBounds, RegVecs, Set, SortedRangeFrags, SpillCost, SpillSlot, TypedIxVec,
-    VirtualRange, VirtualRangeIx, VirtualReg, Writable,
+    BlockIx, InstIx, InstPoint, Map, Point, RangeFrag, RangeFragIx, RangeId, RealRange,
+    RealRangeIx, RealReg, RealRegUniverse, Reg, RegClass, RegVecBounds, RegVecs, RegVecsAndBounds,
+    Set, SortedRangeFrags, SpillCost, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx,
+    VirtualReg, Writable,
 };
-use crate::inst_stream::{edit_inst_stream, InstToInsert, InstToInsertAndPoint};
+use crate::inst_stream::{
+    edit_inst_stream, ExtPoint, InstExtPoint, InstToInsert, InstToInsertAndExtPoint,
+};
 use crate::sparse_set::SparseSetU;
 use crate::union_find::UnionFindEquivClasses;
-use crate::{Function, RegAllocError, RegAllocResult};
+use crate::{AlgorithmWithDefaults, Function, RegAllocError, RegAllocResult, StackmapRequestInfo};
 
 #[derive(Clone)]
 pub struct BacktrackingOptions {
@@ -75,12 +78,21 @@ impl PerRealReg {
     }
 
     #[inline(never)]
-    fn add_RealRange(&mut self, to_add: &RealRange, frag_env: &TypedIxVec<RangeFragIx, RangeFrag>) {
-        // Commit this register to `to_add`, irrevocably.  Don't add it to
-        // `vlrixs_assigned` since we will never want to later evict the
-        // assignment.
-        self.committed
-            .add_indirect(&to_add.sorted_frags, None, frag_env);
+    fn add_RealRange(
+        &mut self,
+        to_add_rlrix: RealRangeIx,
+        rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
+        frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
+    ) {
+        // Commit this register to `to_add`, irrevocably.  Don't add it to `vlrixs_assigned`
+        // since we will never want to later evict the assignment.  (Also, from a types point of
+        // view that would be impossible.)
+        let to_add_rlr = &rlr_env[to_add_rlrix];
+        self.committed.add_indirect(
+            &to_add_rlr.sorted_frags,
+            RangeId::new_real(to_add_rlrix),
+            frag_env,
+        );
     }
 
     #[inline(never)]
@@ -91,7 +103,7 @@ impl PerRealReg {
     ) {
         let to_add_vlr = &vlr_env[to_add_vlrix];
         self.committed
-            .add(&to_add_vlr.sorted_frags, Some(to_add_vlrix));
+            .add(&to_add_vlr.sorted_frags, RangeId::new_virtual(to_add_vlrix));
         assert!(!self.vlrixs_assigned.contains(to_add_vlrix));
         self.vlrixs_assigned.insert(to_add_vlrix);
     }
@@ -103,6 +115,8 @@ impl PerRealReg {
         vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
     ) {
         // Remove it from `vlrixs_assigned`
+        // FIXME 2020June18: we could do this more efficiently by inspecting
+        // the return value from `delete`.
         if self.vlrixs_assigned.contains(to_del_vlrix) {
             self.vlrixs_assigned.delete(to_del_vlrix);
         } else {
@@ -130,7 +144,7 @@ fn search_commitment_tree<IsAllowedToEvict>(
     running_set: &mut SparseSetU<[VirtualRangeIx; 4]>,
     running_cost: &mut SpillCost,
     // The tree to search.
-    tree: &AVLTree<RangeFragAndVLRIx>,
+    tree: &AVLTree<RangeFragAndRangeId>,
     // The RangeFrag we want to accommodate.
     pair_frag: &RangeFrag,
     spill_cost_budget: &SpillCost,
@@ -156,14 +170,14 @@ where
         // Let's first consider the current node.  If we need it but it's not
         // evictable, we might as well stop now.
         if overlaps_curr {
-            // This frag has no associated VirtualRangeIx, so it is part of a
-            // RealRange, and hence not evictable.
-            if curr_node_item.mb_vlrix.is_none() {
+            // This frag is committed to a real range, not a virtual one, and hence is not
+            // evictable.
+            if curr_node_item.id.is_real() {
                 return false;
             }
             // Maybe this one is a spill range, in which case, it can't be
             // evicted.
-            let vlrix_to_evict = curr_node_item.mb_vlrix.unwrap();
+            let vlrix_to_evict = curr_node_item.id.to_virtual();
             let vlr_to_evict = &vlr_env[vlrix_to_evict];
             if vlr_to_evict.spill_cost.is_infinite() {
                 return false;
@@ -369,6 +383,162 @@ fn print_RA_state(
 }
 
 //=============================================================================
+// Reftype/stackmap support
+
+// This creates the artefacts for a safepoint/stackmap at some insn `iix`: the set of reftyped
+// spill slots, the spills to be placed at `iix.r` (yes, you read that right) and the reloads to
+// be placed at `iix.s`.
+//
+// This consults:
+//
+// * the commitment maps, to figure out which real registers are live and reftyped at `iix.u`.
+//
+// * the spillslot allocator, to figure out which spill slots are live and reftyped at `iix.u`.
+//
+// This may fail, meaning the request is in some way nonsensical; failure is propagated upwards.
+
+fn get_stackmap_artefacts_at(
+    spill_slot_allocator: &mut SpillSlotAllocator,
+    univ: &RealRegUniverse,
+    reftype_class: RegClass,
+    reg_vecs_and_bounds: &RegVecsAndBounds,
+    per_real_reg: &Vec<PerRealReg>,
+    rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
+    vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
+    iix: InstIx,
+) -> Result<(Vec<InstToInsert>, Vec<InstToInsert>, Vec<SpillSlot>), RegAllocError> {
+    // From a code generation perspective, what we need to compute is:
+    //
+    // * Sbefore: real regs that are live at `iix.u`, that are reftypes
+    //
+    // * Safter:  Sbefore - real regs written by `iix`
+    //
+    // Then:
+    //
+    // * for r in Sbefore . add "spill r" at `iix.r` *after* all the reloads that are already
+    //   there
+    //
+    // * for r in Safter . add "reload r" at `iix.s` *before* all the spills that are already
+    //   there
+    //
+    // Once those spills have been "recorded" by the `spill_slot_allocator`, we can then ask it
+    // to tell us all the reftyped spill slots at `iix.u`, and that's our stackmap! This routine
+    // only computes the stackmap and the vectors of spills and reloads.  It doesn't deal with
+    // interleaving them into the final code sequence.
+    //
+    // Note that this scheme isn't as runtime-inefficient as it sounds, at least in the
+    // SpiderMonkey use case and where `iix` is a call insn.  That's because SM's calling
+    // convention has no callee saved registers.  Hence "real regs written by `iix`" will be
+    // "all real regs" and so Safter will be empty.  And Sbefore is in any case pretty small.
+    //
+    // (/me thinks ..) hmm, if Safter is empty, then what is the point of dumping Sbefore on the
+    // stack before the GC?  For r in Sbefore, either r is the only reference to some object, in
+    // which case there's no point in presenting that ref to the GC since r is dead after call,
+    // or r isn't the only ref to the object, in which case some other ref to it must exist
+    // elsewhere in the stack, and that will keep the object alive.  Maybe this needs a rethink.
+    // Maybe the spills before the call should be only for the set Safter?
+
+    let pt = InstPoint::new_use(iix);
+
+    // Compute Sbefore.
+
+    // FIXME change this to SparseSet
+    let mut s_before = Set::<RealReg>::empty();
+
+    let rci = univ.allocable_by_class[reftype_class.rc_to_usize()];
+    if rci.is_none() {
+        return Err(RegAllocError::Other(
+            "stackmap request: no regs in specified reftype class".to_string(),
+        ));
+    }
+    let rci = rci.unwrap();
+
+    for rreg_no in rci.first..rci.last + 1 {
+        // Get the RangeId, if any, assigned for `rreg_no` at `iix.u`.  From that we can figure
+        // out if it is reftyped.
+        let mb_range_id = per_real_reg[rreg_no].committed.lookup_inst_point(pt);
+        if let Some(range_id) = mb_range_id {
+            // `rreg_no` is live at `iix.u`.
+            let is_ref = if range_id.is_real() {
+                rlr_env[range_id.to_real()].is_ref
+            } else {
+                vlr_env[range_id.to_virtual()].is_ref
+            };
+            if is_ref {
+                // Finally .. we know that `rreg_no` is reftyped and live at `iix.u`.
+                let rreg = univ.regs[rreg_no].0;
+                s_before.insert(rreg);
+            }
+        }
+    }
+
+    // Compute Safter.
+
+    let mut s_after = s_before.clone();
+    let bounds = &reg_vecs_and_bounds.bounds[iix];
+    if bounds.mods_len != 0 {
+        // Only the GC is allowed to modify reftyped regs at this insn!
+        return Err(RegAllocError::Other(
+            "stackmap request: safepoint insn modifies a reftyped reg".to_string(),
+        ));
+    }
+
+    for i in bounds.defs_start..bounds.defs_start + bounds.defs_len as u32 {
+        let r_defd = reg_vecs_and_bounds.vecs.defs[i as usize];
+        if r_defd.is_real() && r_defd.get_class() == reftype_class {
+            s_after.delete(r_defd.to_real_reg());
+        }
+    }
+
+    // Create the spill insns, as defined by Sbefore.  This has the side effect of recording the
+    // spill in `spill_slot_allocator`, so we can later ask it to tell us all the reftyped spill
+    // slots.
+
+    let frag = RangeFrag::new(InstPoint::new_reload(iix), InstPoint::new_spill(iix));
+
+    let mut spill_insns = Vec::<InstToInsert>::new();
+    let mut where_reg_got_spilled_to = Map::<RealReg, SpillSlot>::default();
+
+    for from_reg in s_before.iter() {
+        let to_slot = spill_slot_allocator.alloc_reftyped_spillslot_for_frag(frag.clone());
+        let spill = InstToInsert::Spill {
+            to_slot,
+            from_reg: *from_reg,
+            for_vreg: None, // spill isn't associated with any virtual reg
+        };
+        spill_insns.push(spill);
+        // We also need to remember where we stashed it, so we can reload it, if it is in Safter.
+        if s_after.contains(*from_reg) {
+            where_reg_got_spilled_to.insert(*from_reg, to_slot);
+        }
+    }
+
+    // Create the reload insns, as defined by Safter.  Except, we might as well use the map we
+    // just made, since its domain is the same as Safter.
+
+    let mut reload_insns = Vec::<InstToInsert>::new();
+
+    for (to_reg, from_slot) in where_reg_got_spilled_to.iter() {
+        let reload = InstToInsert::Reload {
+            to_reg: Writable::from_reg(*to_reg),
+            from_slot: *from_slot,
+            for_vreg: None, // reload isn't associated with any virtual reg
+        };
+        reload_insns.push(reload);
+    }
+
+    // And finally .. round up all the reftyped spill slots.  That includes both "normal" spill
+    // slots that happen to hold reftyped values, as well as the "extras" we created here, to
+    // hold values of reftyped regs that are live over this instruction.
+
+    let reftyped_spillslots = spill_slot_allocator.get_reftyped_spillslots_at_inst_point(pt);
+
+    // And we're done!
+
+    Ok((spill_insns, reload_insns, reftyped_spillslots))
+}
+
+//=============================================================================
 // Allocator top level
 
 /* (const) For each virtual live range
@@ -471,9 +641,23 @@ impl fmt::Debug for EditListItem {
 pub fn alloc_main<F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
+    stackmap_request: &Option<StackmapRequestInfo>,
     use_checker: bool,
     opts: &BacktrackingOptions,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
+    // -------- Initial arrangements for stackmaps --------
+    let empty_vec_vregs = vec![];
+    let empty_vec_iixs = vec![];
+    let (client_wants_stackmaps, reftype_class, reftyped_vregs, safepoint_insns) =
+        match stackmap_request {
+            Some(StackmapRequestInfo {
+                reftype_class,
+                reftyped_vregs,
+                safepoint_insns,
+            }) => (true, *reftype_class, reftyped_vregs, safepoint_insns),
+            None => (false, RegClass::INVALID, &empty_vec_vregs, &empty_vec_iixs),
+        };
+
     // -------- Perform initial liveness analysis --------
     // Note that the analysis phase can fail; hence we propagate any error.
     let AnalysisInfo {
@@ -484,26 +668,38 @@ pub fn alloc_main<F: Function>(
         range_metrics: frag_metrics_env,
         estimated_frequencies: est_freqs,
         inst_to_block_map,
-        ..
-    } = run_analysis(func, reg_universe).map_err(|err| RegAllocError::Analysis(err))?;
+        reg_to_ranges_maps: mb_reg_to_ranges_maps,
+        move_info: mb_move_info,
+    } = run_analysis(
+        func,
+        reg_universe,
+        AlgorithmWithDefaults::Backtracking,
+        client_wants_stackmaps,
+        reftype_class,
+        reftyped_vregs,
+    )
+    .map_err(|err| RegAllocError::Analysis(err))?;
 
     assert!(reg_vecs_and_bounds.is_sanitized());
     assert!(frag_env.len() == frag_metrics_env.len());
+    assert!(mb_reg_to_ranges_maps.is_some()); // ensured by `run_analysis`
+    assert!(mb_move_info.is_some()); // ensured by `run_analysis`
+    let reg_to_ranges_maps = mb_reg_to_ranges_maps.unwrap();
+    let move_info = mb_move_info.unwrap();
 
-    // Also perform analysis that finds all coalesing opportunities.
+    // Also perform analysis that finds all coalescing opportunities.
     let coalescing_info = do_coalescing_analysis(
         func,
-        &reg_vecs_and_bounds,
+        &reg_universe,
         &rlr_env,
         &mut vlr_env,
         &frag_env,
-        &est_freqs,
-        &reg_universe,
+        &reg_to_ranges_maps,
+        &move_info,
     );
     let mut hints: TypedIxVec<VirtualRangeIx, SmallVec<[Hint; 8]>> = coalescing_info.0;
     let vlrEquivClasses: UnionFindEquivClasses<VirtualRangeIx> = coalescing_info.1;
     let is_vv_boundary_move: TypedIxVec<InstIx, bool> = coalescing_info.2;
-    let vreg_to_vlrs_map: Vec</*vreg index,*/ SmallVec<[VirtualRangeIx; 3]>> = coalescing_info.3;
     assert!(hints.len() == vlr_env.len());
 
     // -------- Alloc main --------
@@ -533,7 +729,8 @@ pub fn alloc_main<F: Function>(
         // PerRealReg
         per_real_reg.push(PerRealReg::new());
     }
-    for rlr in rlr_env.iter() {
+    for (rlrix_no, rlr) in rlr_env.iter().enumerate() {
+        let rlrix = RealRangeIx::new(rlrix_no as u32);
         let rregIndex = rlr.rreg.get_index();
         // Ignore RealRanges for RealRegs that are not part of the allocatable
         // set.  As far as the allocator is concerned, such RealRegs simply
@@ -541,7 +738,7 @@ pub fn alloc_main<F: Function>(
         if rregIndex >= reg_universe.allocable {
             continue;
         }
-        per_real_reg[rregIndex].add_RealRange(&rlr, &frag_env);
+        per_real_reg[rregIndex].add_RealRange(rlrix, &rlr_env, &frag_env);
     }
 
     let mut edit_list_move = Vec::<EditListItem>::new();
@@ -977,6 +1174,7 @@ pub fn alloc_main<F: Function>(
 
         let curr_vlr_vreg = curr_vlr.vreg;
         let curr_vlr_reg = curr_vlr_vreg.to_reg();
+        let curr_vlr_is_ref = curr_vlr.is_ref;
 
         for frag in &curr_vlr.sorted_frags.frags {
             for iix in frag.first.iix().dotdot(frag.last.iix().plus(1)) {
@@ -1076,6 +1274,7 @@ pub fn alloc_main<F: Function>(
                 vreg: curr_vlr_vreg,
                 rreg: None,
                 sorted_frags: new_vlr_sfrags,
+                is_ref: curr_vlr_is_ref, // "inherit" refness
                 size: 1,
                 // Effectively infinite.  We'll never look at this again anyway.
                 total_cost: 0xFFFF_FFFFu32,
@@ -1109,7 +1308,7 @@ pub fn alloc_main<F: Function>(
                         // allocated to the same reg as the destination of the
                         // move.  That means we have to find the VLR that owns
                         // the destination vreg.
-                        for vlrix in &vreg_to_vlrs_map[dst_vreg.get_index()] {
+                        for vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[dst_vreg.get_index()] {
                             if vlr_env[*vlrix].vreg == dst_vreg {
                                 new_vlr_hint.push(Hint::SameAs(*vlrix, bridge_eef));
                                 break;
@@ -1120,7 +1319,7 @@ pub fn alloc_main<F: Function>(
                         // Def-to-Spill bridge.  Hint that we want to be
                         // allocated to the same reg as the source of the
                         // move.
-                        for vlrix in &vreg_to_vlrs_map[src_vreg.get_index()] {
+                        for vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[src_vreg.get_index()] {
                             if vlr_env[*vlrix].vreg == src_vreg {
                                 new_vlr_hint.push(Hint::SameAs(*vlrix, bridge_eef));
                                 break;
@@ -1315,7 +1514,7 @@ pub fn alloc_main<F: Function>(
     // Reload and spill instructions are missing.  To generate them, go through
     // the "edit list", which contains info on both how to generate the
     // instructions, and where to insert them.
-    let mut spills_n_reloads = Vec::<InstToInsertAndPoint>::new();
+    let mut spills_n_reloads = Vec::<InstToInsertAndExtPoint>::new();
     let mut num_spills = 0; // stats only
     let mut num_reloads = 0; // stats only
     for eli in &edit_list_other {
@@ -1334,10 +1533,10 @@ pub fn alloc_main<F: Function>(
                 let insnR = InstToInsert::Reload {
                     to_reg: Writable::from_reg(rreg),
                     from_slot: eli.slot,
-                    for_vreg: vreg,
+                    for_vreg: Some(vreg),
                 };
-                let whereToR = vlr_frag.first;
-                spills_n_reloads.push(InstToInsertAndPoint::new(insnR, whereToR));
+                let whereToR = InstExtPoint::from_inst_point(vlr_frag.first);
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(insnR, whereToR));
                 num_reloads += 1;
             }
             BridgeKind::RtoS => {
@@ -1347,17 +1546,17 @@ pub fn alloc_main<F: Function>(
                 let insnR = InstToInsert::Reload {
                     to_reg: Writable::from_reg(rreg),
                     from_slot: eli.slot,
-                    for_vreg: vreg,
+                    for_vreg: Some(vreg),
                 };
-                let whereToR = vlr_frag.first;
+                let whereToR = InstExtPoint::from_inst_point(vlr_frag.first);
                 let insnS = InstToInsert::Spill {
                     to_slot: eli.slot,
                     from_reg: rreg,
-                    for_vreg: vreg,
+                    for_vreg: Some(vreg),
                 };
-                let whereToS = vlr_frag.last;
-                spills_n_reloads.push(InstToInsertAndPoint::new(insnR, whereToR));
-                spills_n_reloads.push(InstToInsertAndPoint::new(insnS, whereToS));
+                let whereToS = InstExtPoint::from_inst_point(vlr_frag.last);
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(insnR, whereToR));
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(insnS, whereToS));
                 num_reloads += 1;
                 num_spills += 1;
             }
@@ -1368,10 +1567,10 @@ pub fn alloc_main<F: Function>(
                 let insnS = InstToInsert::Spill {
                     to_slot: eli.slot,
                     from_reg: rreg,
-                    for_vreg: vreg,
+                    for_vreg: Some(vreg),
                 };
-                let whereToS = vlr_frag.last;
-                spills_n_reloads.push(InstToInsertAndPoint::new(insnS, whereToS));
+                let whereToS = InstExtPoint::from_inst_point(vlr_frag.last);
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(insnS, whereToS));
                 num_spills += 1;
             }
         }
@@ -1408,10 +1607,64 @@ pub fn alloc_main<F: Function>(
         }
     }
 
+    // There is one of these for every entry in `safepoint_insns`.
+    let mut stackmaps = Vec::<Vec<SpillSlot>>::new();
+
+    if !safepoint_insns.is_empty() {
+        info!("alloc_main:   create safepoints and stackmaps");
+        for safepoint_iix in safepoint_insns {
+            // Create the stackmap artefacts for `safepoint_iix`.  Save the stackmap (the
+            // reftyped spillslots); we'll have to return it to the client as part of the
+            // overall allocation result.  The extra spill and reload instructions can simply
+            // be added to `spills_n_reloads` though, and `edit_inst_stream` will correctly
+            // merge them in.
+            //
+            // Note: this modifies `spill_slot_allocator`, since at this point we have to
+            // allocate spill slots to hold reftyped real regs across the safepoint insn.
+            //
+            // Because the SB (spill-before) and RA (reload-after) `ExtPoint`s are "closer" to
+            // the "core" of an instruction than the R (reload) and S (spill) `ExtPoint`s, any
+            // "normal" reload or spill ranges that are reftyped will be handled correctly.
+            // From `get_stackmap_artefacts_at`s point of view, such spill/reload ranges are
+            // just like any other real-reg live range that it will have to spill around the
+            // safepoint.  The fact that they are for spills or reloads doesn't make any
+            // difference.
+            //
+            // Note also: this call can fail; failure is propagated upwards.
+            //
+            // FIXME Passing these 3 small vectors around is inefficient.  Use SmallVec or
+            // (better) owned-by-this-function vectors instead.
+            let (spills_before, reloads_after, reftyped_spillslots) = get_stackmap_artefacts_at(
+                &mut spill_slot_allocator,
+                &reg_universe,
+                reftype_class,
+                &reg_vecs_and_bounds,
+                &per_real_reg,
+                &rlr_env,
+                &vlr_env,
+                *safepoint_iix,
+            )?;
+            stackmaps.push(reftyped_spillslots);
+            for spill_before in spills_before {
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(
+                    spill_before,
+                    InstExtPoint::new(*safepoint_iix, ExtPoint::SpillBefore),
+                ));
+            }
+            for reload_after in reloads_after {
+                spills_n_reloads.push(InstToInsertAndExtPoint::new(
+                    reload_after,
+                    InstExtPoint::new(*safepoint_iix, ExtPoint::ReloadAfter),
+                ));
+            }
+        }
+    }
+
     info!("alloc_main:   edit_inst_stream");
 
-    let final_insns_and_targetmap__or_err = edit_inst_stream(
+    let final_insns_and_targetmap_and_new_safepoints__or_err = edit_inst_stream(
         func,
+        &safepoint_insns,
         spills_n_reloads,
         &iixs_to_nop_out,
         frag_map,
@@ -1423,7 +1676,7 @@ pub fn alloc_main<F: Function>(
 
     // ======== BEGIN Create the RegAllocResult ========
 
-    match final_insns_and_targetmap__or_err {
+    match final_insns_and_targetmap_and_new_safepoints__or_err {
         Ok((ref final_insns, ..)) => {
             info!(
                 "alloc_main:   out: VLRs: {} initially, {} processed",
@@ -1450,16 +1703,17 @@ pub fn alloc_main<F: Function>(
         }
     }
 
-    let (final_insns, target_map, orig_insn_map) = match final_insns_and_targetmap__or_err {
-        Err(e) => {
-            info!("alloc_main: fail");
-            return Err(e);
-        }
-        Ok(pair) => {
-            info!("alloc_main:   creating RegAllocResult");
-            pair
-        }
-    };
+    let (final_insns, target_map, new_to_old_insn_map, new_safepoint_insns) =
+        match final_insns_and_targetmap_and_new_safepoints__or_err {
+            Err(e) => {
+                info!("alloc_main: fail");
+                return Err(e);
+            }
+            Ok(quad) => {
+                info!("alloc_main:   creating RegAllocResult");
+                quad
+            }
+        };
 
     // Compute clobbered registers with one final, quick pass.
     //
@@ -1475,7 +1729,7 @@ pub fn alloc_main<F: Function>(
 
     let mut clobbered_registers: Set<RealReg> = Set::empty();
 
-    // We'll dump all the reg uses in here.  We don't care the bounds, so just
+    // We'll dump all the reg uses in here.  We don't care about the bounds, so just
     // pass a dummy one in the loop.
     let mut reg_vecs = RegVecs::new(/*sanitized=*/ false);
     let mut dummy_bounds = RegVecBounds::new();
@@ -1509,13 +1763,17 @@ pub fn alloc_main<F: Function>(
         block_annotations = Some(anns);
     }
 
+    assert!(stackmaps.len() == safepoint_insns.len());
+    assert!(new_safepoint_insns.len() == safepoint_insns.len());
     let ra_res = RegAllocResult {
         insns: final_insns,
         target_map,
-        orig_insn_map,
+        orig_insn_map: new_to_old_insn_map,
         clobbered_registers,
         num_spill_slots: spill_slot_allocator.num_slots_in_use() as u32,
         block_annotations,
+        stackmaps,
+        new_safepoint_insns,
     };
 
     info!("alloc_main: end");

--- a/lib/src/bt_spillslot_allocator.rs
+++ b/lib/src/bt_spillslot_allocator.rs
@@ -5,7 +5,7 @@
 
 use crate::avl_tree::{AVLTree, AVL_NULL};
 use crate::data_structures::{
-    cmp_range_frags, RangeFrag, SortedRangeFrags, SpillSlot, TypedIxVec, VirtualRange,
+    cmp_range_frags, InstPoint, RangeFrag, SortedRangeFrags, SpillSlot, TypedIxVec, VirtualRange,
     VirtualRangeIx,
 };
 use crate::union_find::UnionFindEquivClasses;
@@ -28,6 +28,22 @@ use crate::Function;
 //=============================================================================
 // Logical spill slots
 
+// In the trees, we keep track of which frags are reftyped, so we can later create stackmaps by
+// slicing all of the trees at some `InstPoint`.  Unfortunately this requires storing 65 bits of
+// data in each node -- 64 bits for the RangeFrag and 1 bit for the reftype.  A TODO would be to
+// steal one bit from the RangeFrag.  For now though, we do the simple thing.
+
+#[derive(Clone, PartialEq, PartialOrd)]
+struct RangeFragAndRefness {
+    frag: RangeFrag,
+    is_ref: bool,
+}
+impl RangeFragAndRefness {
+    fn new(frag: RangeFrag, is_ref: bool) -> Self {
+        Self { frag, is_ref }
+    }
+}
+
 // We keep one of these for every "logical spill slot" in use.
 enum LogicalSpillSlot {
     // This slot is in use and can hold values of size `size` (only).  Note that
@@ -36,7 +52,10 @@ enum LogicalSpillSlot {
     // `SpillSlotAllocator::slots`, the next `size` - 1 entries must be
     // `Unavail`.  This is a hard invariant, violation of which will cause
     // overlapping spill slots and potential chaos.
-    InUse { size: u32, tree: AVLTree<RangeFrag> },
+    InUse {
+        size: u32,
+        tree: AVLTree<RangeFragAndRefness>,
+    },
     // This slot is unavailable, as described above.  It's unavailable because
     // it holds some part of the values associated with the nearest lower
     // numbered entry which isn't `Unavail`, and that entry must be an `InUse`
@@ -53,13 +72,13 @@ impl LogicalSpillSlot {
     fn is_InUse(&self) -> bool {
         !self.is_Unavail()
     }
-    fn get_tree(&self) -> &AVLTree<RangeFrag> {
+    fn get_tree(&self) -> &AVLTree<RangeFragAndRefness> {
         match self {
             LogicalSpillSlot::InUse { ref tree, .. } => tree,
             LogicalSpillSlot::Unavail => panic!("LogicalSpillSlot::get_tree"),
         }
     }
-    fn get_mut_tree(&mut self) -> &mut AVLTree<RangeFrag> {
+    fn get_mut_tree(&mut self) -> &mut AVLTree<RangeFragAndRefness> {
         match self {
             LogicalSpillSlot::InUse { ref mut tree, .. } => tree,
             LogicalSpillSlot::Unavail => panic!("LogicalSpillSlot::get_mut_tree"),
@@ -71,6 +90,62 @@ impl LogicalSpillSlot {
             LogicalSpillSlot::Unavail => panic!("LogicalSpillSlot::get_size"),
         }
     }
+    // If this spill slot is occupied at `pt`, return the refness of the value (VirtualRange)
+    // stored in it.  This is conceptually equivalent to CommitmentMap::lookup_inst_point.
+    fn get_refness_at_inst_point(&self, pt: InstPoint) -> Option<bool> {
+        match self {
+            LogicalSpillSlot::InUse { size: 1, tree } => {
+                // Search the tree to see if a reffy commitment intersects `pt`.
+                let mut root = tree.root;
+                while root != AVL_NULL {
+                    let root_node = &tree.pool[root as usize];
+                    let root_item = &root_node.item;
+                    if pt < root_item.frag.first {
+                        // `pt` is to the left of the `root`.  So there's no
+                        // overlap with `root`.  Continue by inspecting the left subtree.
+                        root = root_node.left;
+                    } else if root_item.frag.last < pt {
+                        // Ditto for the right subtree.
+                        root = root_node.right;
+                    } else {
+                        // `pt` overlaps the `root`, so we have what we want.
+                        return Some(root_item.is_ref);
+                    }
+                }
+                None
+            }
+            LogicalSpillSlot::InUse { .. } | LogicalSpillSlot::Unavail => {
+                // Slot isn't is use, or is in use but for values of some non-ref size
+                None
+            }
+        }
+    }
+}
+
+// HELPER FUNCTION
+// Find out whether it is possible to add `frag` to `tree`.
+#[inline(always)]
+fn ssal_is_add_frag_possible(tree: &AVLTree<RangeFragAndRefness>, frag: &RangeFrag) -> bool {
+    // BEGIN check `frag` for any overlap against `tree`.
+    let mut root = tree.root;
+    while root != AVL_NULL {
+        let root_node = &tree.pool[root as usize];
+        let root_item = &root_node.item;
+        if frag.last < root_item.frag.first {
+            // `frag` is entirely to the left of the `root`.  So there's no
+            // overlap with root.  Continue by inspecting the left subtree.
+            root = root_node.left;
+        } else if root_item.frag.last < frag.first {
+            // Ditto for the right subtree.
+            root = root_node.right;
+        } else {
+            // `frag` overlaps the `root`.  Give up.
+            return false;
+        }
+    }
+    // END check `frag` for any overlap against `tree`.
+    // `frag` doesn't overlap.
+    true
 }
 
 // HELPER FUNCTION
@@ -81,27 +156,12 @@ impl LogicalSpillSlot {
 // no guarantee that elements of `frags` don't overlap `tree`.  Hence we have
 // to do a custom walk of `tree` to check for overlap; we can't just use
 // `AVLTree::contains`.
-fn ssal_is_add_possible(tree: &AVLTree<RangeFrag>, frags: &SortedRangeFrags) -> bool {
+fn ssal_is_add_possible(tree: &AVLTree<RangeFragAndRefness>, frags: &SortedRangeFrags) -> bool {
     // Figure out whether all the frags will go in.
     for frag in &frags.frags {
-        // BEGIN check `frag` for any overlap against `tree`.
-        let mut root = tree.root;
-        while root != AVL_NULL {
-            let root_node = &tree.pool[root as usize];
-            let root_frag = root_node.item.clone();
-            if frag.last < root_frag.first {
-                // `frag` is entirely to the left of the `root`.  So there's no
-                // overlap with root.  Continue by inspecting the left subtree.
-                root = root_node.left;
-            } else if root_frag.last < frag.first {
-                // Ditto for the right subtree.
-                root = root_node.right;
-            } else {
-                // `frag` overlaps the `root`.  Give up.
-                return false;
-            }
+        if !ssal_is_add_frag_possible(&tree, frag) {
+            return false;
         }
-        // END check `frag` for any overlap against `tree`.
         // `frag` doesn't overlap.  Move on to the next one.
     }
     true
@@ -112,7 +172,11 @@ fn ssal_is_add_possible(tree: &AVLTree<RangeFrag>, frags: &SortedRangeFrags) -> 
 // not possible.  If `false` is returned, `tree` is unchanged (this is
 // important).  This routine relies on the fact that SortedFrags is
 // non-overlapping.
-fn ssal_add_if_possible(tree: &mut AVLTree<RangeFrag>, frags: &SortedRangeFrags) -> bool {
+fn ssal_add_if_possible(
+    tree: &mut AVLTree<RangeFragAndRefness>,
+    frags: &SortedRangeFrags,
+    frags_are_ref: bool,
+) -> bool {
     // Check if all the frags will go in.
     if !ssal_is_add_possible(tree, frags) {
         return false;
@@ -120,8 +184,10 @@ fn ssal_add_if_possible(tree: &mut AVLTree<RangeFrag>, frags: &SortedRangeFrags)
     // They will.  So now insert them.
     for frag in &frags.frags {
         let inserted = tree.insert(
-            frag.clone(),
-            Some(&|frag1, frag2| cmp_range_frags(&frag1, &frag2)),
+            RangeFragAndRefness::new(frag.clone(), frags_are_ref),
+            Some(&|item1: RangeFragAndRefness, item2: RangeFragAndRefness| {
+                cmp_range_frags(&item1.frag, &item2.frag)
+            }),
         );
         // This can't fail
         assert!(inserted);
@@ -155,9 +221,11 @@ impl SpillSlotAllocator {
         while self.slots.len() % (req_size as usize) != 0 {
             self.slots.push(LogicalSpillSlot::Unavail);
         }
-        // And now the new slot.
-        let dflt = RangeFrag::invalid_value();
-        let tree = AVLTree::<RangeFrag>::new(dflt);
+        // And now the new slot.  The `dflt` value is needed by `AVLTree` to initialise storage
+        // slots for tree nodes, but we will never actually see those values.  So it doesn't
+        // matter what they are.
+        let dflt = RangeFragAndRefness::new(RangeFrag::invalid_value(), false);
+        let tree = AVLTree::<RangeFragAndRefness>::new(dflt);
         let res = self.slots.len() as u32;
         self.slots.push(LogicalSpillSlot::InUse {
             size: req_size,
@@ -176,6 +244,7 @@ impl SpillSlotAllocator {
         res
     }
 
+    // THE MAIN FUNCTION
     // Allocate spill slots for all the VirtualRanges in `vlrix`s eclass,
     // including `vlrix` itself.  Since we are allocating spill slots for
     // complete eclasses at once, none of the members of the class should
@@ -191,8 +260,25 @@ impl SpillSlotAllocator {
         vlrEquivClasses: &UnionFindEquivClasses<VirtualRangeIx>,
         vlrix: VirtualRangeIx,
     ) {
+        let is_ref = vlr_env[vlrix].is_ref;
         for cand_vlrix in vlrEquivClasses.equiv_class_elems_iter(vlrix) {
+            // "None of the VLRs in this equivalence class have an allocated spill slot."
+            // This should be true because we allocate spill slots for all of the members of an
+            // eclass at once.
             assert!(vlr_slot_env[cand_vlrix].is_none());
+
+            // "All of the VLRs in this eclass have the same ref-ness as this VLR."
+            // Why this is true is a bit subtle.  The equivalence classes are computed by
+            // `do_coalescing_analysis`, fundamentally by looking at all the move instructions
+            // and computing the transitive closure induced by them.  The ref-ness annotations
+            // on each VLR are computed in `do_reftypes_analysis`, and they are also computed
+            // as a transitive closure on the same move instructions.  Hence the results should
+            // be identical.
+            //
+            // With all that said, note that these equivalence classes are *not* guaranteed to
+            // be internally non-overlapping.  This is explained in the big block comment at the
+            // top of bt_coalescing_analysis.rs.
+            assert!(vlr_env[cand_vlrix].is_ref == is_ref);
         }
 
         // Do this in two passes.  It's a bit cumbersome.
@@ -242,6 +328,12 @@ impl SpillSlotAllocator {
         let vlrix_vreg = vlr_env[vlrix].vreg;
         let req_size = func.get_spillslot_size(vlrix_vreg.get_class(), vlrix_vreg);
         assert!(req_size == 1 || req_size == 2 || req_size == 4 || req_size == 8);
+
+        // Sanity check: if the VLR is reftyped, then it must need a 1-word slot
+        // (anything else is nonsensical.)
+        if is_ref {
+            assert!(req_size == 1);
+        }
 
         // Pass 1: find a slot which can take all VirtualRanges in `vlrix`s
         // eclass when tested individually.
@@ -304,7 +396,7 @@ impl SpillSlotAllocator {
         'pass2_per_equiv_class: for cand_vlrix in vlrEquivClasses.equiv_class_elems_iter(vlrix) {
             let cand_vlr = &vlr_env[cand_vlrix];
             let mut tree = self.slots[chosen_slotno as usize].get_mut_tree();
-            let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags);
+            let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags, is_ref);
             if added {
                 vlr_slot_env[cand_vlrix] = Some(SpillSlot::new(chosen_slotno));
                 continue 'pass2_per_equiv_class;
@@ -324,7 +416,7 @@ impl SpillSlotAllocator {
                     continue;
                 }
                 let mut tree = self.slots[alt_slotno as usize].get_mut_tree();
-                let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags);
+                let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags, is_ref);
                 if added {
                     vlr_slot_env[cand_vlrix] = Some(SpillSlot::new(alt_slotno));
                     continue 'pass2_per_equiv_class;
@@ -334,7 +426,7 @@ impl SpillSlotAllocator {
             // So allocate a new one and use that.
             let new_slotno = self.add_new_slot(req_size);
             let mut tree = self.slots[new_slotno as usize].get_mut_tree();
-            let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags);
+            let added = ssal_add_if_possible(&mut tree, &cand_vlr.sorted_frags, is_ref);
             if added {
                 vlr_slot_env[cand_vlrix] = Some(SpillSlot::new(new_slotno));
                 continue 'pass2_per_equiv_class;
@@ -343,5 +435,52 @@ impl SpillSlotAllocator {
             panic!("SpillSlotAllocator: alloc_spill_slots: failed?!?!");
             /*NOTREACHED*/
         } /* 'pass2_per_equiv_class */
+    }
+
+    // STACKMAP SUPPORT
+    // Allocate a size-1 (word!) spill slot for `frag` and return it.  The slot is marked
+    // reftyped so that a later call to `get_reftyped_spillslots_at_inst_point` will return it.
+    pub fn alloc_reftyped_spillslot_for_frag(&mut self, frag: RangeFrag) -> SpillSlot {
+        for i in 0..self.slots.len() {
+            match &mut self.slots[i] {
+                LogicalSpillSlot::InUse { size: 1, tree } => {
+                    if ssal_is_add_frag_possible(&tree, &frag) {
+                        // We're in luck.
+                        let inserted = tree.insert(
+                            RangeFragAndRefness::new(frag, /*is_ref=*/ true),
+                            Some(&|item1: RangeFragAndRefness, item2: RangeFragAndRefness| {
+                                cmp_range_frags(&item1.frag, &item2.frag)
+                            }),
+                        );
+                        // This can't fail -- we just checked for it!
+                        assert!(inserted);
+                        return SpillSlot::new(i as u32);
+                    }
+                    // Otherwise move on.
+                }
+                LogicalSpillSlot::InUse { .. } | LogicalSpillSlot::Unavail => {
+                    // Slot isn't is use, or is in use but for values of some non-ref size.
+                    // Move on.
+                }
+            }
+        }
+        // We tried all slots, but without success.  Add a new one and try again.  This time we
+        // must succeed.  Calling recursively is a bit stupid in the sense that we then search
+        // again to find the slot we just allocated, but hey.
+        self.add_new_slot(1 /*word*/);
+        return self.alloc_reftyped_spillslot_for_frag(frag); // \o/ tailcall \o/
+    }
+
+    // STACKMAP SUPPORT
+    // Examine all the spill slots at `pt` and return those that are reftyped.  This is
+    // fundamentally what creates a stack map.
+    pub fn get_reftyped_spillslots_at_inst_point(&self, pt: InstPoint) -> Vec<SpillSlot> {
+        let mut res = Vec::<SpillSlot>::new();
+        for (i, slot) in self.slots.iter().enumerate() {
+            if slot.get_refness_at_inst_point(pt) == Some(true) {
+                res.push(SpillSlot::new(i as u32));
+            }
+        }
+        res
     }
 }

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -1194,7 +1194,7 @@ pub struct RealRegUniverse {
     pub regs: Vec<(RealReg, String)>,
 
     // This is the size of the initial section of `regs` that is available to
-    // the allocator.  It must be < `regs`.len().
+    // the allocator.  It must be <= `regs`.len().
     pub allocable: usize,
 
     // Information about groups of allocable registers. Used to quickly address
@@ -1997,19 +1997,27 @@ impl SpillCost {
 pub struct RealRange {
     pub rreg: RealReg,
     pub sorted_frags: SortedRangeFragIxs,
+    pub is_ref: bool,
 }
 
 impl fmt::Debug for RealRange {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "(RR: {:?}, {:?})", self.rreg, self.sorted_frags)
+        write!(
+            fmt,
+            "(RR: {:?}{}, {:?})",
+            self.rreg,
+            if self.is_ref { " REF" } else { "" },
+            self.sorted_frags
+        )
     }
 }
 
 impl RealRange {
     pub fn show_with_rru(&self, univ: &RealRegUniverse) -> String {
         format!(
-            "(RR: {}, {:?})",
+            "(RR: {}{}, {:?})",
             self.rreg.to_reg().show_with_rru(univ),
+            if self.is_ref { " REF" } else { "" },
             self.sorted_frags
         )
     }
@@ -2026,6 +2034,7 @@ pub struct VirtualRange {
     pub vreg: VirtualReg,
     pub rreg: Option<RealReg>,
     pub sorted_frags: SortedRangeFrags,
+    pub is_ref: bool,
     pub size: u16,
     pub total_cost: u32,
     pub spill_cost: SpillCost, // == total_cost / size
@@ -2039,7 +2048,12 @@ impl VirtualRange {
 
 impl fmt::Debug for VirtualRange {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "(VR: {:?},", self.vreg)?;
+        write!(
+            fmt,
+            "(VR: {:?}{},",
+            self.vreg,
+            if self.is_ref { " REF" } else { "" }
+        )?;
         if self.rreg.is_some() {
             write!(fmt, " -> {:?}", self.rreg.unwrap())?;
         }
@@ -2048,6 +2062,107 @@ impl fmt::Debug for VirtualRange {
             " sz={}, tc={}, sc={:?}, {:?})",
             self.size, self.total_cost, self.spill_cost, self.sorted_frags
         )
+    }
+}
+
+//=============================================================================
+// Some auxiliary/miscellaneous data structures that are useful.
+
+// Mappings from RealRegs and VirtualRegs to the sets of RealRanges and VirtualRanges that
+// belong to them.  These are needed for BT's coalescing analysis and for the dataflow analysis
+// that supports reftype handling.
+
+pub struct RegToRangesMaps {
+    // This maps RealReg indices to the set of RealRangeIxs for that RealReg.  Valid indices are
+    // real register indices for all non-sanitised real regs; that is,
+    // 0 .. RealRegUniverse::allocable, for ".." having the Rust meaning.  The Vecs of
+    // RealRangeIxs are duplicate-free.  They are Vec rather than SmallVec because they are often
+    // large, so SmallVec would just be a disadvantage here.
+    pub rreg_to_rlrs_map: Vec</*real reg ix, */ Vec<RealRangeIx>>,
+
+    // This maps VirtualReg indices to the set of VirtualRangeIxs for that VirtualReg.  Valid
+    // indices are 0 .. Function::get_num_vregs().  For functions mostly translated from SSA,
+    // most VirtualRegs will have just one VirtualRange, and there are a lot of VirtualRegs in
+    // general.  So SmallVec is a definite benefit here.
+    pub vreg_to_vlrs_map: Vec</*virtual reg ix, */ SmallVec<[VirtualRangeIx; 3]>>,
+}
+
+// MoveInfo holds info about registers connected by moves.  For each, we record the source and
+// destination of the move, the insn performing the move, and the estimated execution frequency
+// of the containing block.  The moves are not presented in any particular order, but they are
+// duplicate-free in that each such instruction will be listed only once.
+
+pub struct MoveInfoElem {
+    pub dst: Reg,
+    pub src: Reg,
+    pub iix: InstIx,
+    pub est_freq: u32,
+}
+
+pub struct MoveInfo {
+    pub moves: Vec<MoveInfoElem>,
+}
+
+// Something that can be either a VirtualRangeIx or a RealRangeIx, whilst still being 32 bits
+// (by stealing one bit from those spaces).  Note that the resulting thing no longer denotes a
+// contiguous index space, and so it has a name that indicates it is an identifier rather than
+// an index.
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct RangeId {
+    // 1 X--(31)--X is a RealRangeIx with value X--(31)--X
+    // 0 X--(31)--X is a VirtualRangeIx with value X--(31)--X
+    bits: u32,
+}
+
+impl RangeId {
+    #[inline(always)]
+    pub fn new_real(rlrix: RealRangeIx) -> Self {
+        let n = rlrix.get();
+        assert!(n <= 0x7FFF_FFFF);
+        Self {
+            bits: n | 0x8000_0000,
+        }
+    }
+    #[inline(always)]
+    pub fn new_virtual(vlrix: VirtualRangeIx) -> Self {
+        let n = vlrix.get();
+        assert!(n <= 0x7FFF_FFFF);
+        Self { bits: n }
+    }
+    #[inline(always)]
+    pub fn is_real(self) -> bool {
+        self.bits & 0x8000_0000 != 0
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub fn is_virtual(self) -> bool {
+        self.bits & 0x8000_0000 == 0
+    }
+    #[inline(always)]
+    pub fn to_real(self) -> RealRangeIx {
+        assert!(self.bits & 0x8000_0000 != 0);
+        RealRangeIx::new(self.bits & 0x7FFF_FFFF)
+    }
+    #[inline(always)]
+    pub fn to_virtual(self) -> VirtualRangeIx {
+        assert!(self.bits & 0x8000_0000 == 0);
+        VirtualRangeIx::new(self.bits)
+    }
+    #[inline(always)]
+    pub fn invalid_value() -> Self {
+        // Real, and inplausibly huge
+        Self { bits: 0xFFFF_FFFF }
+    }
+}
+
+impl fmt::Debug for RangeId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_real() {
+            self.to_real().fmt(fmt)
+        } else {
+            self.to_virtual().fmt(fmt)
+        }
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,6 +15,7 @@ mod analysis_main;
 
 mod analysis_control_flow;
 mod analysis_data_flow;
+mod analysis_reftypes;
 mod avl_tree;
 mod bt_coalescing_analysis;
 mod bt_commitment_map;
@@ -266,21 +267,26 @@ pub trait Function {
 
     /// Generate a spill instruction for insertion into the instruction
     /// sequence. The associated virtual register (whose value is being spilled)
-    /// is passed so that the client may make decisions about the instruction to
-    /// generate based on the type of value in question.  Because the register
-    /// allocator will insert spill instructions at arbitrary points, the
-    /// returned instruction here must not modify the machine's condition codes.
-    fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg, for_vreg: VirtualReg) -> Self::Inst;
+    /// is passed, if it exists, so that the client may make decisions about the
+    /// instruction to generate based on the type of value in question.  Because
+    /// the register allocator will insert spill instructions at arbitrary points,
+    /// the returned instruction here must not modify the machine's condition codes.
+    fn gen_spill(
+        &self,
+        to_slot: SpillSlot,
+        from_reg: RealReg,
+        for_vreg: Option<VirtualReg>,
+    ) -> Self::Inst;
 
     /// Generate a reload instruction for insertion into the instruction
     /// sequence. The associated virtual register (whose value is being loaded)
-    /// is passed as well.  The returned instruction must not modify the
-    /// machine's condition codes.
+    /// is passed as well, if it exists.  The returned instruction must not modify
+    /// the machine's condition codes.
     fn gen_reload(
         &self,
         to_reg: Writable<RealReg>,
         from_slot: SpillSlot,
-        for_vreg: VirtualReg,
+        for_vreg: Option<VirtualReg>,
     ) -> Self::Inst;
 
     /// Generate a register-to-register move for insertion into the instruction
@@ -367,6 +373,14 @@ pub struct RegAllocResult<F: Function> {
     /// call to `allocate_registers`.  Creating of these annotations is
     /// potentially expensive, so don't request them if you don't need them.
     pub block_annotations: Option<TypedIxVec<BlockIx, Vec<String>>>,
+
+    /// If stackmap support was requested: one stackmap for each of the safepoint instructions
+    /// declared.  Otherwise empty.
+    pub stackmaps: Vec<Vec<SpillSlot>>,
+
+    /// If stackmap support was requested: one InstIx for each safepoint instruction declared,
+    /// indicating the corresponding location in the final instruction stream.  Otherwise empty.
+    pub new_safepoint_insns: Vec<InstIx>,
 }
 
 /// A choice of register allocation algorithm to run.
@@ -444,16 +458,36 @@ impl fmt::Debug for Options {
     }
 }
 
+/// A structure with which callers can request stackmap information.
+pub struct StackmapRequestInfo {
+    /// The register class that holds reftypes.  This may only be RegClass::I32 or
+    /// RegClass::I64, and it must equal the word size of the target architecture.
+    pub reftype_class: RegClass,
+
+    /// The virtual regs that hold reftyped values.  These must be provided in ascending order
+    /// of register index and be duplicate-free.  They must have class `reftype_class`.
+    reftyped_vregs: Vec<VirtualReg>,
+
+    /// The indices of instructions for which the allocator will construct stackmaps.  These
+    /// must be provided in ascending order and be duplicate-free.  The specified instructions
+    /// may not be coalescable move instructions (as the allocator may remove those) and they
+    /// may not modify any register carrying a reftyped value (they may "def" or "use" them,
+    /// though).  The reason is that, at a safepoint, the client's garbage collector may change
+    /// the values of all live references, so it would be meaningless for a safepoint
+    /// instruction also to attempt to do that -- we'd end up with two competing new values.
+    safepoint_insns: Vec<InstIx>,
+}
+
 /// Allocate registers for a function's code, given a universe of real registers that we are
-/// allowed to use.
+/// allowed to use.  Optionally, stackmap support may be requested.
 ///
 /// The control flow graph must not contain any critical edges, that is, any edge coming from a
 /// block with multiple successors must not flow into a block with multiple predecessors. The
 /// embedder must have split critical edges before handing over the function to this function.
 /// Otherwise, an error will be returned.
 ///
-/// Allocate may succeed, returning a `RegAllocResult` with the new instruction sequence, or it may
-/// fail, returning an error.
+/// Allocation may succeed, returning a `RegAllocResult` with the new instruction sequence, or
+/// it may fail, returning an error.
 ///
 /// Runtime options can be passed to the allocators, through the use of [Options] for options
 /// common to all the backends. The choice of algorithm is done by passing a given [Algorithm]
@@ -462,6 +496,7 @@ impl fmt::Debug for Options {
 pub fn allocate_registers_with_opts<F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
+    stackmap_info: &Option<StackmapRequestInfo>,
     opts: Options,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     info!("");
@@ -474,10 +509,69 @@ pub fn allocate_registers_with_opts<F: Function>(
             info!("  {}", s);
         }
     }
+    // If stackmap support has been requested, perform some initial sanity checks.
+    if let Some(StackmapRequestInfo {
+        reftype_class,
+        reftyped_vregs,
+        safepoint_insns,
+    }) = stackmap_info
+    {
+        if let Algorithm::LinearScan(_) = opts.algorithm {
+            return Err(RegAllocError::Other(
+                "stackmap request: not currently available for Linear Scan".to_string(),
+            ));
+        }
+        if *reftype_class != RegClass::I64 && *reftype_class != RegClass::I32 {
+            return Err(RegAllocError::Other(
+                "stackmap request: invalid reftype_class".to_string(),
+            ));
+        }
+        let num_avail_vregs = func.get_num_vregs();
+        for i in 0..reftyped_vregs.len() {
+            let vreg = &reftyped_vregs[i];
+            if vreg.get_class() != *reftype_class {
+                return Err(RegAllocError::Other(
+                    "stackmap request: invalid vreg class".to_string(),
+                ));
+            }
+            if vreg.get_index() >= num_avail_vregs {
+                return Err(RegAllocError::Other(
+                    "stackmap request: out of range vreg".to_string(),
+                ));
+            }
+            if i > 0 && reftyped_vregs[i - 1].get_index() >= vreg.get_index() {
+                return Err(RegAllocError::Other(
+                    "stackmap request: non-ascending vregs".to_string(),
+                ));
+            }
+        }
+        let num_avail_insns = func.insns().len();
+        for i in 0..safepoint_insns.len() {
+            let safepoint_iix = safepoint_insns[i];
+            if safepoint_iix.get() as usize >= num_avail_insns {
+                return Err(RegAllocError::Other(
+                    "stackmap request: out of range safepoint insn".to_string(),
+                ));
+            }
+            if i > 0 && safepoint_insns[i - 1].get() >= safepoint_iix.get() {
+                return Err(RegAllocError::Other(
+                    "stackmap request: non-ascending safepoint insns".to_string(),
+                ));
+            }
+            if func.is_move(func.get_insn(safepoint_iix)).is_some() {
+                return Err(RegAllocError::Other(
+                    "stackmap request: safepoint insn is a move insn".to_string(),
+                ));
+            }
+        }
+        // We can't check here that reftyped regs are not changed by safepoint insns.  That is
+        // done deep in the stackmap creation logic, for BT in `get_stackmap_artefacts_at`.
+    }
+
     let run_checker = opts.run_checker;
     let res = match &opts.algorithm {
         Algorithm::Backtracking(opts) => {
-            bt_main::alloc_main(func, rreg_universe, run_checker, opts)
+            bt_main::alloc_main(func, rreg_universe, stackmap_info, run_checker, opts)
         }
         Algorithm::LinearScan(opts) => linear_scan::run(func, rreg_universe, run_checker, opts),
     };
@@ -502,6 +596,7 @@ pub fn allocate_registers_with_opts<F: Function>(
 pub fn allocate_registers<F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
+    stackmap_info: &Option<StackmapRequestInfo>,
     algorithm: AlgorithmWithDefaults,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
     let algorithm = match algorithm {
@@ -512,7 +607,7 @@ pub fn allocate_registers<F: Function>(
         algorithm,
         ..Default::default()
     };
-    allocate_registers_with_opts(func, rreg_universe, opts)
+    allocate_registers_with_opts(func, rreg_universe, stackmap_info, opts)
 }
 
 // Facilities to snapshot regalloc inputs and reproduce them in regalloc.rs.

--- a/lib/src/snapshot.rs
+++ b/lib/src/snapshot.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 enum IRInstKind {
-    Spill { vreg: VirtualReg },
-    Reload { vreg: VirtualReg },
+    Spill { vreg: Option<VirtualReg> },
+    Reload { vreg: Option<VirtualReg> },
     Move { vreg: VirtualReg },
     ZeroLenNop,
     UserReturn,
@@ -158,7 +158,12 @@ impl IRSnapshot {
     }
 
     pub fn allocate(&mut self, opts: Options) -> Result<RegAllocResult<IRFunction>, RegAllocError> {
-        allocate_registers_with_opts(&mut self.func, &self.reg_universe, opts)
+        allocate_registers_with_opts(
+            &mut self.func,
+            &self.reg_universe,
+            &None, /*no stackmap request*/
+            opts,
+        )
     }
 }
 
@@ -253,7 +258,7 @@ impl Function for IRFunction {
         &self,
         _to_slot: SpillSlot,
         from_reg: RealReg,
-        for_vreg: VirtualReg,
+        for_vreg: Option<VirtualReg>,
     ) -> Self::Inst {
         IRInst {
             reg_uses: vec![from_reg.to_reg()],
@@ -266,7 +271,7 @@ impl Function for IRFunction {
         &self,
         to_reg: Writable<RealReg>,
         _from_slot: SpillSlot,
-        for_vreg: VirtualReg,
+        for_vreg: Option<VirtualReg>,
     ) -> Self::Inst {
         IRInst {
             reg_uses: vec![],


### PR DESCRIPTION
…y, BT only).  A summary of

the changes is:

* If the client wants stackmap/reftypes support, it has to provide three extra pieces of
  information:
  - the register class holding reftyped values, on the target
  - the set of VirtualRegs that hold reftyped values (that it created)
  - the set of instructions for which stackmaps (and, implicitly, safepoints) are required.
  In return it is given:
  - for each safepoint instruction, the set of stack slots holding reftyped values
  - a mapping from old safepoint instruction indicies to the final insn indices, since the
    allocator will both add and remove instructions

* For RealRanges and VirtualRanges, there is an extra bool to indicate whether the range is
  reftyped.

* Some analysis work needed by both the reftype dataflow analysis (see next point) and BT's
  coalescing machinery, has been refactored so as to avoid doing it twice.  Specifically,
  computation of maps from RealRegs to RealRanges and from VirtualRegs to VirtualRanges.

* A dataflow analysis phase used only when reftype support is requested.  From the initial set
  of reftyped virtual registers (not ranges), compute the set of all VirtualRanges and
  RealRanges that are reftyped.  This is done in the new file analysis_reftypes.rs.  Note this
  code is buggy and Chris has a fix which will land later.  It is also inefficient and will need
  to be rewritten once it is more stable.

* In the spill slot allocator, keep track of which slots at which ranges are allocated to a
  reftyped VirtualRange.  Add a mechanism to query each slot's tree at some instruction so as to
  see whether that slot contains a reftyped value at that instruction.

* For each instruction at which the client requests stackmaps, do the following:

  - Add instructions that spill live reftyped RealRegs onto the stack, just before the insn, and
    add spill slots as necessary to hold them.

  - Similarly, add instructions to reload, after the instruction, the subset of spilled values
    which remain live after the call.

  The effect is to force all reftyped values onto the stack at each safepoint, which allows them
  to be updated by the GC that implicitly runs "in the middle of the safepoint", and then to
  reload those values into RealRegs as required.

  - Finally, then, consult the StackSlotAllocator's state at each safepoint instruction.  This
    gives the set of slots that are reftyped, which is the basis for making stackmaps.

* In bt_coalescing_analysis.rs, fn do_coalescing_analysis, there has been a drive-by cleanup:
  the two strangely named closures `doesVRegHaveXXat` and `doesRRegHaveXXat`, which tool a bool
  indicating the meaning of the `XX`, have each been split in half, and the bool removed.  This
  gives four closures, no runtime interpretation of booleans, and simpler to follow code.

* In the case where reftype support is not requested, the changes are performance neutral.  In
  fact there is some extra overhead, but that is more than cancelled out by a small
  representational improvement in CommitmentMap.