### PR TITLE
Add checker and fuzzing support for reftypes.

### DIFF
--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -120,14 +120,16 @@ fn main() {
 
     // Just so we can run it later.  Not needed for actual allocation.
     let original_func = func.clone();
+    let sri = func.get_stackmap_request();
 
-    let result = match allocate_registers_with_opts(&mut func, &reg_universe, None, opts.clone()) {
-        Err(e) => {
-            println!("allocation failed: {}", e);
-            return;
-        }
-        Ok(r) => r,
-    };
+    let result =
+        match allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts.clone()) {
+            Err(e) => {
+                println!("allocation failed: {}", e);
+                return;
+            }
+            Ok(r) => r,
+        };
 
     let num_spill_slots = result.num_spill_slots;
 

--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -276,7 +276,8 @@ mod test_utils {
             &reg_universe,
             RunStage::BeforeRegalloc,
         );
-        let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
+        let sri = func.get_stackmap_request();
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts)
             .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });

--- a/bin/parser.rs
+++ b/bin/parser.rs
@@ -745,6 +745,24 @@ pub fn parse_content(func_name: &str, content: &str) -> ParseResult<Func> {
                     insts.push(i_storef(addr, src));
                 }
 
+                "makeref" => {
+                    let dst = parser.read_var()?;
+                    parser.expect_char(',')?;
+                    let src = parser.read_var()?;
+                    insts.push(Inst::MakeRef { dst, src });
+                }
+
+                "useref" => {
+                    let dst = parser.read_var()?;
+                    parser.expect_char(',')?;
+                    let src = parser.read_var()?;
+                    insts.push(Inst::UseRef { dst, src });
+                }
+
+                "safepoint" => {
+                    insts.push(Inst::Safepoint);
+                }
+
                 "sub" => {
                     let dst = parser.read_var()?;
                     parser.expect_char(',')?;

--- a/bin/parser.rs
+++ b/bin/parser.rs
@@ -428,7 +428,11 @@ pub fn parse_content(func_name: &str, content: &str) -> ParseResult<Func> {
     loop {
         name = parser.read_ident()?;
         let c = parser.read_char()?;
-        if c == '=' {
+        if &name == "reftype_start" && c == '=' {
+            let index = parser.read_int()?;
+            parser.func.reftype_reg_start = index;
+        }
+        else if c == '=' {
             // variable declaration.
             let real_or_class = parser.read_ident()?;
             if real_or_class == "real" {

--- a/bin/parser.rs
+++ b/bin/parser.rs
@@ -431,8 +431,7 @@ pub fn parse_content(func_name: &str, content: &str) -> ParseResult<Func> {
         if &name == "reftype_start" && c == '=' {
             let index = parser.read_int()?;
             parser.func.reftype_reg_start = index;
-        }
-        else if c == '=' {
+        } else if c == '=' {
             // variable declaration.
             let real_or_class = parser.read_ident()?;
             if real_or_class == "real" {

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -9,6 +9,8 @@ use std::{borrow::Cow, fmt};
 
 use crate::validator::{validate, Context as ValidatorContext, RegRef};
 
+use log::debug;
+
 //=============================================================================
 // Definition of: Label, RI (reg-or-immediate operands), AM (address modes),
 // and Inst (instructions).  Also the get-regs and map-regs operations for
@@ -1938,6 +1940,10 @@ impl Func {
                     _ => {}
                 }
             }
+            debug!(
+                "SRI: reftyped_vregs = {:?}, safepoint_insns = {:?}",
+                reftyped_vregs, safepoint_insns
+            );
             Some(StackmapRequestInfo {
                 reftype_class: RegClass::I32,
                 reftyped_vregs,

--- a/bin/test_framework.rs
+++ b/bin/test_framework.rs
@@ -1191,7 +1191,7 @@ impl PartialEq for Value {
             },
 
             Value::F32(x) => match other {
-                Value::F32(y) => (x != x && y != y) || x == y,
+                Value::F32(y) => (x.is_nan() && y.is_nan()) || x == y,
                 _ => false,
             },
 

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -29,7 +29,7 @@ fuzz_target!(|func: ir::Func| {
     if false {
         println!("BEGIN INPUT:");
         let mut rendered = String::new();
-        func.render("==== fuzz_bt.rs: failing input:", &mut rendered)
+        func.render("==== fuzz_bt.rs: input:", &mut rendered)
             .unwrap();
         println!("{}", rendered);
         println!("END INPUT:");
@@ -48,7 +48,8 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, None, opts);
+    let sri = func.get_stackmap_request();
+    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts);
 
     match ra_result {
         Ok(result) => {

--- a/fuzz/fuzz_bt.rs
+++ b/fuzz/fuzz_bt.rs
@@ -43,8 +43,7 @@ fuzz_target!(|func: ir::Func| {
     let func_backup = func.clone();
 
     let opts = regalloc::Options {
-        //TODO reenable checking once #47 is fixed.
-        run_checker: false,
+        run_checker: true,
 
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1512,11 +1512,6 @@ pub fn alloc_main<F: Function>(
                 | (Point::Def, Point::Spill, Point::Reload, Point::Use) => {
                     let slot1 = edit_list_move[i_min].slot;
                     let slot2 = edit_list_move[i_max].slot;
-                    let (from_reg, to_reg) = if frag1.last.pt() == Point::Use {
-                        (vlr1.vreg.to_reg(), vlr2.vreg.to_reg())
-                    } else {
-                        (vlr2.vreg.to_reg(), vlr1.vreg.to_reg())
-                    };
                     if slot1 == slot2 {
                         // Yay.  We've found a coalescable pair.  We can just ignore the
                         // two entries and move on.  Except we have to mark the insn
@@ -1526,8 +1521,13 @@ pub fn alloc_main<F: Function>(
                         i_min = i_max + 1;
                         n_edit_list_move_processed += 2;
                         if use_checker {
+                            let (from_reg, to_reg) = if frag1.last.pt() == Point::Use {
+                                (vlr1.vreg.to_reg(), vlr2.vreg.to_reg())
+                            } else {
+                                (vlr2.vreg.to_reg(), vlr1.vreg.to_reg())
+                            };
                             ghost_moves.push(InstToInsertAndExtPoint::new(
-                                InstToInsert::SSMove {
+                                InstToInsert::ChangeSpillSlotOwnership {
                                     inst_ix: i_min_iix,
                                     slot: slot1,
                                     from_reg,

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1463,6 +1463,7 @@ pub fn alloc_main<F: Function>(
     // `edit_list_sorted` is), and the indices in it refer to the original
     // virtual-registerised code.
     let mut iixs_to_nop_out = Vec::<InstIx>::new();
+    let mut ghost_moves = vec![];
 
     let n_edit_list_move = edit_list_move.len();
     let mut n_edit_list_move_processed = 0; // for assertions only
@@ -1511,6 +1512,11 @@ pub fn alloc_main<F: Function>(
                 | (Point::Def, Point::Spill, Point::Reload, Point::Use) => {
                     let slot1 = edit_list_move[i_min].slot;
                     let slot2 = edit_list_move[i_max].slot;
+                    let (from_reg, to_reg) = if frag1.last.pt() == Point::Use {
+                        (vlr1.vreg.to_reg(), vlr2.vreg.to_reg())
+                    } else {
+                        (vlr2.vreg.to_reg(), vlr1.vreg.to_reg())
+                    };
                     if slot1 == slot2 {
                         // Yay.  We've found a coalescable pair.  We can just ignore the
                         // two entries and move on.  Except we have to mark the insn
@@ -1519,6 +1525,17 @@ pub fn alloc_main<F: Function>(
                         iixs_to_nop_out.push(i_min_iix);
                         i_min = i_max + 1;
                         n_edit_list_move_processed += 2;
+                        if use_checker {
+                            ghost_moves.push(InstToInsertAndExtPoint::new(
+                                InstToInsert::SSMove {
+                                    inst_ix: i_min_iix,
+                                    slot: slot1,
+                                    from_reg,
+                                    to_reg,
+                                },
+                                InstExtPoint::new(i_min_iix, ExtPoint::Reload),
+                            ));
+                        }
                         continue;
                     }
                 }
@@ -1607,6 +1624,12 @@ pub fn alloc_main<F: Function>(
                 num_spills += 1;
             }
         }
+    }
+
+    // Append all ghost moves.
+    if use_checker {
+        spills_n_reloads.extend(ghost_moves.into_iter());
+        spills_n_reloads.sort_by_key(|inst_and_point| inst_and_point.iep.clone());
     }
 
     // ======== END Create all other spills and reloads ========

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1726,6 +1726,8 @@ pub fn alloc_main<F: Function>(
         frag_map,
         &reg_universe,
         use_checker,
+        &stackmaps[..],
+        &reftyped_vregs[..],
     );
 
     // ======== END Create final instruction stream ========

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -248,7 +248,7 @@ impl CheckerState {
                     }
                 }
             }
-            &Inst::SSMove {
+            &Inst::ChangeSpillSlotOwnership {
                 inst_ix,
                 slot,
                 from_reg,
@@ -346,7 +346,7 @@ impl CheckerState {
                     .unwrap_or(Default::default());
                 self.reg_values.insert(into.to_reg(), val);
             }
-            &Inst::SSMove { slot, to_reg, .. } => {
+            &Inst::ChangeSpillSlotOwnership { slot, to_reg, .. } => {
                 let reftyped = if let Some(val) = self.spill_slots.get(&slot) {
                     match val {
                         &CheckerValue::Reg(_, reftyped) => reftyped,
@@ -399,7 +399,7 @@ pub(crate) enum Inst {
     /// A spillslot ghost move (between vregs) resulting from an user-program
     /// move whose source and destination regs are both vregs that are currently
     /// spilled.
-    SSMove {
+    ChangeSpillSlotOwnership {
         inst_ix: InstIx,
         slot: SpillSlot,
         from_reg: Reg,
@@ -679,8 +679,8 @@ impl CheckerContext {
             for checker_inst in self.checker_inst_map.get(&pre_point).unwrap_or(&empty) {
                 debug!("at inst {:?}: pre checker_inst: {:?}", iix, checker_inst);
                 self.checker.add_inst(bix, checker_inst.clone());
-                if let Inst::SSMove { .. } = checker_inst {
-                    // Unlike spills/reloads/moves inserted by the regalloc, SSMove
+                if let Inst::ChangeSpillSlotOwnership { .. } = checker_inst {
+                    // Unlike spills/reloads/moves inserted by the regalloc, ChangeSpillSlotOwnership
                     // pseudo-insts replace the instruction itself.
                     skip_inst = true;
                 }

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -62,6 +62,7 @@ use crate::data_structures::{
 use crate::inst_stream::{ExtPoint, InstExtPoint, InstToInsertAndExtPoint};
 use crate::{Function, RegUsageMapper};
 
+use rustc_hash::FxHashSet;
 use std::collections::VecDeque;
 use std::default::Default;
 use std::hash::Hash;
@@ -103,6 +104,14 @@ pub enum CheckerError {
         actual: Reg,
         inst: InstIx,
     },
+    StackMapSpecifiesNonRefSlot {
+        inst: InstIx,
+        slot: SpillSlot,
+    },
+    StackMapSpecifiesUndefinedSlot {
+        inst: InstIx,
+        slot: SpillSlot,
+    },
 }
 
 /// Abstract state for a storage slot (real register or spill slot).
@@ -119,7 +128,9 @@ enum CheckerValue {
     /// Reg: this storage slot has a value that originated as a def into
     /// the given register, either implicitly (RealRegs at beginning of
     /// function) or explicitly (as an instruction's def).
-    Reg(Reg),
+    ///
+    /// The boolean flag indicates whether the value is reference-typed.
+    Reg(Reg, bool),
 }
 
 impl Default for CheckerValue {
@@ -136,7 +147,9 @@ impl CheckerValue {
             (_, &CheckerValue::Unknown) => *self,
             (&CheckerValue::Conflicted, _) => *self,
             (_, &CheckerValue::Conflicted) => *other,
-            _ if *self == *other => *self,
+            (&CheckerValue::Reg(r1, ref1), &CheckerValue::Reg(r2, ref2)) if r1 == r2 => {
+                CheckerValue::Reg(r1, ref1 || ref2)
+            }
             _ => CheckerValue::Conflicted,
         }
     }
@@ -183,7 +196,7 @@ impl CheckerState {
         for &(rreg, _) in &ru.regs {
             state
                 .reg_values
-                .insert(rreg, CheckerValue::Reg(rreg.to_reg()));
+                .insert(rreg, CheckerValue::Reg(rreg.to_reg(), false));
         }
         state
     }
@@ -223,7 +236,7 @@ impl CheckerState {
                                 inst: inst_ix,
                             });
                         }
-                        CheckerValue::Reg(r) if r != orig => {
+                        CheckerValue::Reg(r, _) if r != orig => {
                             return Err(CheckerError::IncorrectValueInReg {
                                 actual: r,
                                 expected: orig,
@@ -255,7 +268,7 @@ impl CheckerState {
                             inst: inst_ix,
                         });
                     }
-                    CheckerValue::Reg(r) if r != from_reg => {
+                    CheckerValue::Reg(r, _) if r != from_reg => {
                         return Err(CheckerError::IncorrectValueInSlot {
                             slot,
                             expected: from_reg,
@@ -266,9 +279,43 @@ impl CheckerState {
                     _ => {}
                 }
             }
+            &Inst::Safepoint { inst_ix, ref slots } => {
+                self.check_stackmap(inst_ix, slots)?;
+            }
             _ => {}
         }
         Ok(())
+    }
+
+    fn check_stackmap(&self, inst: InstIx, slots: &Vec<SpillSlot>) -> Result<(), CheckerError> {
+        // N.B.: it's OK for the stackmap to omit a slot that has a ref value in
+        // it; it might be dead. We simply update such a slot's value to
+        // 'undefined' in the transfer function.
+        for &slot in slots {
+            match self.spill_slots.get(&slot) {
+                Some(CheckerValue::Reg(_, false)) => {
+                    return Err(CheckerError::StackMapSpecifiesNonRefSlot { inst, slot });
+                }
+                Some(CheckerValue::Reg(_, true)) => {
+                    // OK.
+                }
+                _ => {
+                    return Err(CheckerError::StackMapSpecifiesUndefinedSlot { inst, slot });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn update_stackmap(&mut self, slots: &Vec<SpillSlot>) {
+        for (&slot, val) in &mut self.spill_slots {
+            if let &mut CheckerValue::Reg(_, true) = val {
+                let in_stackmap = slots.binary_search(&slot).is_ok();
+                if !in_stackmap {
+                    *val = CheckerValue::Unknown;
+                }
+            }
+        }
     }
 
     /// Update according to instruction.
@@ -277,13 +324,18 @@ impl CheckerState {
             &Inst::Op {
                 ref defs_orig,
                 ref defs,
+                ref defs_reftyped,
                 ..
             } => {
                 // For each def, set the symbolic value of the mapped RealReg to a
                 // symbol corresponding to the original def.
                 assert!(defs_orig.len() == defs.len());
-                for (orig, mapped) in defs_orig.iter().cloned().zip(defs.iter().cloned()) {
-                    self.reg_values.insert(mapped, CheckerValue::Reg(orig));
+                for i in 0..defs.len() {
+                    let orig = defs_orig[i];
+                    let mapped = defs[i];
+                    let reftyped = defs_reftyped[i];
+                    self.reg_values
+                        .insert(mapped, CheckerValue::Reg(orig, reftyped));
                 }
             }
             &Inst::Move { into, from } => {
@@ -295,7 +347,16 @@ impl CheckerState {
                 self.reg_values.insert(into.to_reg(), val);
             }
             &Inst::SSMove { slot, to_reg, .. } => {
-                self.spill_slots.insert(slot, CheckerValue::Reg(to_reg));
+                let reftyped = if let Some(val) = self.spill_slots.get(&slot) {
+                    match val {
+                        &CheckerValue::Reg(_, reftyped) => reftyped,
+                        _ => false,
+                    }
+                } else {
+                    false
+                };
+                self.spill_slots
+                    .insert(slot, CheckerValue::Reg(to_reg, reftyped));
             }
             &Inst::Spill { into, from } => {
                 let val = self
@@ -312,6 +373,9 @@ impl CheckerState {
                     .cloned()
                     .unwrap_or(Default::default());
                 self.reg_values.insert(into.to_reg(), val);
+            }
+            &Inst::Safepoint { ref slots, .. } => {
+                self.update_stackmap(slots);
             }
         }
     }
@@ -349,6 +413,12 @@ pub(crate) enum Inst {
         uses_orig: Vec<Reg>,
         defs: Vec<RealReg>,
         uses: Vec<RealReg>,
+        defs_reftyped: Vec<bool>,
+    },
+    /// A safepoint, with a list of expected slots.
+    Safepoint {
+        inst_ix: InstIx,
+        slots: Vec<SpillSlot>,
     },
 }
 
@@ -358,6 +428,7 @@ pub(crate) struct Checker {
     bb_in: Map<BlockIx, CheckerState>,
     bb_succs: Map<BlockIx, Vec<BlockIx>>,
     bb_insts: Map<BlockIx, Vec<Inst>>,
+    reftyped_vregs: FxHashSet<VirtualReg>,
 }
 
 fn map_regs<F: Fn(VirtualReg) -> Option<RealReg>>(
@@ -394,7 +465,11 @@ impl Checker {
     /// Create a new checker for the given function, initializing CFG info immediately.
     /// The client should call the `add_*()` methods to add abstract instructions to each
     /// BB before invoking `run()` to check for errors.
-    pub(crate) fn new<F: Function>(f: &F, ru: &RealRegUniverse) -> Checker {
+    pub(crate) fn new<F: Function>(
+        f: &F,
+        ru: &RealRegUniverse,
+        reftyped_vregs: &[VirtualReg],
+    ) -> Checker {
         let mut bb_in = Map::default();
         let mut bb_succs = Map::default();
         let mut bb_insts = Map::default();
@@ -407,11 +482,13 @@ impl Checker {
 
         bb_in.insert(f.entry_block(), CheckerState::entry_state(ru));
 
+        let reftyped_vregs = reftyped_vregs.iter().cloned().collect::<FxHashSet<_>>();
         Checker {
             bb_entry: f.entry_block(),
             bb_in,
             bb_succs,
             bb_insts,
+            reftyped_vregs,
         }
     }
 
@@ -454,6 +531,10 @@ impl Checker {
         let defs_orig = defs_set.to_vec();
         let uses = map_regs(inst_ix, &uses_orig[..], &|vreg| mapper.get_use(vreg))?;
         let defs = map_regs(inst_ix, &defs_orig[..], &|vreg| mapper.get_def(vreg))?;
+        let defs_reftyped = defs_orig
+            .iter()
+            .map(|reg| reg.is_virtual() && self.reftyped_vregs.contains(&reg.to_virtual_reg()))
+            .collect();
         let insts = self.bb_insts.get_mut(&block).unwrap();
         let op = Inst::Op {
             inst_ix,
@@ -461,6 +542,7 @@ impl Checker {
             defs_orig,
             uses,
             defs,
+            defs_reftyped,
         };
         debug!("add_op: adding {:?}", op);
         insts.push(op);
@@ -526,6 +608,7 @@ impl Checker {
     /// Find any errors, returning `Err(CheckerErrors)` with all errors found
     /// or `Ok(())` otherwise.
     pub(crate) fn run(mut self) -> Result<(), CheckerErrors> {
+        debug!("Checker: full body is:\n{:?}", self.bb_insts);
         self.analyze();
         self.find_errors()
     }
@@ -545,7 +628,11 @@ impl CheckerContext {
         f: &F,
         ru: &RealRegUniverse,
         insts_to_add: &Vec<InstToInsertAndExtPoint>,
+        safepoint_insns: &[InstIx],
+        stackmaps: &[Vec<SpillSlot>],
+        reftyped_vregs: &[VirtualReg],
     ) -> CheckerContext {
+        assert!(safepoint_insns.len() == stackmaps.len());
         let mut checker_inst_map: Map<InstExtPoint, Vec<Inst>> = Map::default();
         for &InstToInsertAndExtPoint { ref inst, ref iep } in insts_to_add {
             let checker_insts = checker_inst_map
@@ -553,7 +640,19 @@ impl CheckerContext {
                 .or_insert_with(|| vec![]);
             checker_insts.push(inst.to_checker_inst());
         }
-        let checker = Checker::new(f, ru);
+        for (iix, slots) in safepoint_insns.iter().zip(stackmaps.iter()) {
+            let iep = InstExtPoint::new(*iix, ExtPoint::Use);
+            let mut slots = slots.clone();
+            slots.sort();
+            checker_inst_map
+                .entry(iep)
+                .or_insert_with(|| vec![])
+                .push(Inst::Safepoint {
+                    inst_ix: *iix,
+                    slots,
+                });
+        }
+        let checker = Checker::new(f, ru, reftyped_vregs);
         CheckerContext {
             checker,
             checker_inst_map,
@@ -571,22 +670,20 @@ impl CheckerContext {
         mapper: &RUM,
     ) -> Result<(), CheckerErrors> {
         let empty = vec![];
-        let pre_point = InstExtPoint::new(iix, ExtPoint::Reload);
-        let post_point = InstExtPoint::new(iix, ExtPoint::Spill);
         let mut skip_inst = false;
 
-        debug!(
-            "CheckerContext::handle_insn: inst {:?}, pre = {:?}, post = {:?}",
-            iix, pre_point, post_point
-        );
+        debug!("CheckerContext::handle_insn: inst {:?}", iix,);
 
-        for checker_inst in self.checker_inst_map.get(&pre_point).unwrap_or(&empty) {
-            debug!("at inst {:?}: pre checker_inst: {:?}", iix, checker_inst);
-            self.checker.add_inst(bix, checker_inst.clone());
-            if let Inst::SSMove { .. } = checker_inst {
-                // Unlike spills/reloads/moves inserted by the regalloc, SSMove
-                // pseudo-insts replace the instruction itself.
-                skip_inst = true;
+        for &pre_point in &[ExtPoint::Reload, ExtPoint::SpillBefore, ExtPoint::Use] {
+            let pre_point = InstExtPoint::new(iix, pre_point);
+            for checker_inst in self.checker_inst_map.get(&pre_point).unwrap_or(&empty) {
+                debug!("at inst {:?}: pre checker_inst: {:?}", iix, checker_inst);
+                self.checker.add_inst(bix, checker_inst.clone());
+                if let Inst::SSMove { .. } = checker_inst {
+                    // Unlike spills/reloads/moves inserted by the regalloc, SSMove
+                    // pseudo-insts replace the instruction itself.
+                    skip_inst = true;
+                }
             }
         }
 
@@ -602,9 +699,12 @@ impl CheckerContext {
             self.checker.add_op(bix, iix, &regsets, mapper)?;
         }
 
-        for checker_inst in self.checker_inst_map.get(&post_point).unwrap_or(&empty) {
-            debug!("at inst {:?}: post checker_inst: {:?}", iix, checker_inst);
-            self.checker.add_inst(bix, checker_inst.clone());
+        for &post_point in &[ExtPoint::ReloadAfter, ExtPoint::Spill] {
+            let post_point = InstExtPoint::new(iix, post_point);
+            for checker_inst in self.checker_inst_map.get(&post_point).unwrap_or(&empty) {
+                debug!("at inst {:?}: post checker_inst: {:?}", iix, checker_inst);
+                self.checker.add_inst(bix, checker_inst.clone());
+            }
         }
 
         Ok(())

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -2187,9 +2187,6 @@ impl RangeId {
         // Real, and inplausibly huge
         Self { bits: 0xFFFF_FFFF }
     }
-    pub fn is_valid(self) -> bool {
-        self != Self::invalid_value()
-    }
 }
 
 impl fmt::Debug for RangeId {

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -939,7 +939,7 @@ impl<R: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug> Wr
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SpillSlot {
     SpillSlot(u32),
 }
@@ -2186,6 +2186,9 @@ impl RangeId {
     pub fn invalid_value() -> Self {
         // Real, and inplausibly huge
         Self { bits: 0xFFFF_FFFF }
+    }
+    pub fn is_valid(self) -> bool {
+        self != Self::invalid_value()
     }
 }
 

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -34,7 +34,7 @@ pub(crate) enum InstToInsert {
     /// track the symbolic values in slots. Always originates from a move
     /// in the original user program whose source and dest vregs are both
     /// spilled.
-    SSMove {
+    ChangeSpillSlotOwnership {
         inst_ix: InstIx,
         slot: SpillSlot,
         from_reg: Reg,
@@ -60,7 +60,7 @@ impl InstToInsert {
                 from_reg,
                 for_vreg,
             } => Some(f.gen_move(to_reg, from_reg, for_vreg)),
-            &InstToInsert::SSMove { .. } => None,
+            &InstToInsert::ChangeSpillSlotOwnership { .. } => None,
         }
     }
 
@@ -84,12 +84,12 @@ impl InstToInsert {
                 into: to_reg,
                 from: from_reg,
             },
-            &InstToInsert::SSMove {
+            &InstToInsert::ChangeSpillSlotOwnership {
                 inst_ix,
                 slot,
                 from_reg,
                 to_reg,
-            } => CheckerInst::SSMove {
+            } => CheckerInst::ChangeSpillSlotOwnership {
                 inst_ix,
                 slot,
                 from_reg,

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -633,7 +633,14 @@ fn set_registers<F: Function>(
     let mut checker: Option<CheckerContext> = None;
     let mut insn_blocks: Vec<BlockIx> = vec![];
     if use_checker {
-        checker = Some(CheckerContext::new(func, reg_universe, memory_moves));
+        checker = Some(CheckerContext::new(
+            func,
+            reg_universe,
+            memory_moves,
+            &[],
+            &[],
+            &[],
+        ));
         insn_blocks.resize(func.insns().len(), BlockIx::new(0));
         for block_ix in func.blocks() {
             for insn_ix in func.block_insns(block_ix) {

--- a/tests/fuzz_ss_coalescing.rat
+++ b/tests/fuzz_ss_coalescing.rat
@@ -1,0 +1,27 @@
+v0I = I32
+v5I = I32
+v7I = I32
+r0I = real I32 0
+r1I = real I32 1
+r2I = real I32 2
+r3I = real I32 3
+r7F = real F32 7
+
+b0:
+    imm     v7I, 16459008
+    imm     v7I, 14876672
+    imm     r1I, 2216295
+    copy    v0I, r1I
+    imm     v5I, 4290624957
+    imm     r0I, 4294967295
+    goto    b1:b1
+
+b1:
+    copy    v7I, v7I
+    cmp_gt  v7I, v0I, r0I
+    add     r3I, v0I, 64293
+    copy    r0I, v5I
+    loadf   r7F, [r1I, 248581882]
+    shr     r1I, v5I, r1I
+    load    r2I, [v7I, 2910114088]
+    goto    b0:b0

--- a/tests/fuzz_stackmap.rat
+++ b/tests/fuzz_stackmap.rat
@@ -1,0 +1,21 @@
+v0I = I32
+v2I = I32
+v13I = I32
+r2I = real I32 2
+
+b0:
+    imm     v0I, 2459079408
+    makeref v13I, v0I
+    cmp_gem v0I, 4294956758
+    load    v2I, [v0I, 4294967295]
+    goto    b1:b1
+
+b1:
+    safepoint
+    load    r2I, [v2I, v0I]
+    useref  r2I, v13I
+    useref  r2I, v13I
+    subm    r2I, 640034342
+    useref  r2I, v13I
+    useref  r2I, v13I
+    goto    b0:b0

--- a/tests/fuzz_stackmap2.rat
+++ b/tests/fuzz_stackmap2.rat
@@ -1,0 +1,25 @@
+v0I = I32
+v2I = I32
+v4I = I32
+v10I = I32
+v13I = I32
+r2I = real I32 2
+
+b0:
+    imm     v0I, 2459079168
+    makeref v13I, v0I
+    store   [v0I, v0I], v0I
+    load    v10I, [v0I, 3523203583]
+    if_then_else v10I, b1:b1, b2:b2
+
+b1:
+    safepoint
+    if_then_else v10I, b0:b0, b0:b0
+
+b2:
+    safepoint
+    load    v2I, [v10I, 4294967295]
+    load    r2I, [v0I, 24080239]
+    copy    v4I, v0I
+    useref  r2I, v13I
+    if_then_else v10I, b0:b0, b0:b0

--- a/tests/fuzz_stackmap3.rat
+++ b/tests/fuzz_stackmap3.rat
@@ -1,0 +1,41 @@
+v0I = I32
+v1I = I32
+v2I = I32
+v13I = I32
+r0I = real I32 0
+r2I = real I32 2
+r3I = real I32 3
+
+b0:
+    safepoint
+    imm     v0I, 201326459
+    load    v1I, [v0I, 3520188881]
+    if_then_else v0I, b0:b0, b1:b1
+
+b1:
+    store   [v1I, 6636287], v0I
+    makeref v13I, v1I
+    cmp_ge  v1I, v1I, v0I
+    copy    r2I, v1I
+    if_then_else r2I, b2:b2, b2:b2
+
+b2:
+    copy    v0I, r2I
+    load    v0I, [r2I, r2I]
+    load    r0I, [v0I, 269597]
+    cmp_gt  v0I, v1I, v1I
+    cmp_gt  v0I, v1I, v1I
+    cmp_gt  v0I, v1I, v1I
+    goto    b3:b3
+
+b3:
+    safepoint
+    cmp_gt  v2I, v1I, v1I
+    sub     r2I, v2I, v1I
+    copy    v13I, v13I
+    imm     r3I, 4294967295
+    useref  v0I, v13I
+    andm    v0I, v0I
+    store   [r0I, r2I], v1I
+    finish
+


### PR DESCRIPTION
This PR adds:
* Checker support for spillslot coalescing (closes #47).
* Fuzzing-infrastructure support for generating programs with reference type defs and uses and safepoints.
* Checker support for validating stackmaps.

Reftype support in `bt` has been fuzzed up to 10.9B test cases without finding an issue (except for an initial issue in the reftypes checker that I fixed).

## Supporting coalesced spillslots

The key idea of this change is to use "ghost instructions" to
communicate information from the register allocator to the checker.
These instructions have no side-effect, by definition, but communicate a
semantic change to the program state that is relevant to verification:
for example, a move from one virtual register to another, when both
virtual registers live in the same spillslot (a "V-V move").

These ghost instructions exist only as edit-list entries; they are never
actually reified into real instructions and inserted, nor does the
machine backend have to have any special support to generate them. They
are just conceptual.

It turns out that to support spill-slot coalescing (i.e. to successfully
check allocation results with this feature enabled), all we need is to
correctly handle these V-V moves. Other forms of coalescing (e.g., a
move between two virtual registers allocated to the same real register)
are already visible to the checker, because it sees these redundant
moves before they are removed.

In a little more detail, the design-space considered included:

1. Extending the checker to reason about storing multiple virtual
   registers in each storage slot / allocation target (real register or
   spill slot). The problem with this approach is that it is much less
   efficient -- analysis values for each slot at each program point are
   no longer fixed 64-bit things but potentially unbounded sets -- and
   that it also loses information, because we may have two different
   programs that store a different vreg in a slot when arriving at a
   program point via different paths. Fundamentally, we should check the
   move at the point that the sets are union'd (the "ghost instruction")
   and then reason only about the (single) "current" vreg in the slot.

2. Reason about collections of equality constraints by assigning
   symbolic names (tags or whatever) to each def (i.e., SSA values) and
   then gathering move-constraints together. This started to get really
   complex, and seems to require basically a full SSA recovery algorithm
   plus a good part of the allocator's analysis, so it was discarded
   (the checker should be simple and straightforward to maximize the
   confidence we have in it).

3. Reason about reaching definitions, and validate the program by
   showing that the same defs reach each use at each instruction in the
   pre-allocated and post-allocated versions. The problem with this is
   similar to option 1 above: it discards information about paths, and
   so is imprecise.

Fundamentally, it seemed that we could either try to design clever
heuristics to *recover* the information about the elided V-V moves, or
we could just observe them directly before they are elided; so the above
ghost-instruction approach was chosen.

## Checking reftype stackmaps

Next, we add stackmap checking to the checker, and fix some stackmap fuzzing
issues.

The checker for stackmaps works as follows:

- Every analysis value in the checker gets a "reffy" bit. These are
  filled in according to the list of reffy vregs provided by the
  regalloc.

- When stackmap information is given for a safepoint, the checker
  verifies that every slot described as reffy by the stackmap is in fact
  reffy.

- Any reffy spillslot that passes through a safepoint *without* being
  named in the stackmap is set to "undefined". Then, if it is later used
  as a reference (or at all), we will detect that it was in fact live
  but was not named in the stackmap.

Note that these rules do *not* do the obvious thing and construct an
expected stackmap from the spillslot state at the safepoint's program
point, then compare it to the given stackmap. This is because a stackmap
is allowed to elide a reffy spillslot that's dead: we could just as
easily have zeroed it out after its last use, as it semantically no
longer exists in the program; we were just too lazy to clear it. We
don't want to reconstruct liveness information and verify that every
reffy-but-not-described-as-such slot is dead in the checker, so instead
we just mark every reffy slot not named as reffy as undefined. This is
somewhat intuitive when seen a certain way: if the GC (or whatever
stackmap consumer) is unaware of a reference value at a safepoint, it
might be outdated (e.g. if the GC moves every object), so might as well
be undefined.

The stackmap checking appears to truly work because it found the above
dead-spillslot issue quite quickly. After fixing that bug, it ran up to
the following state (10.9B test cases) before I killed it:

`#10943745210: cov: 4362 ft: 19953 corp: 2941 exec/s 1577 oom/timeout/crash: 0/0/0 time: 303772s job: 24310 dft_time: 0`