### PR TITLE
Bugfix: fix move-info ranges, and with it, reftypes analysis.

### DIFF
--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -46,7 +46,7 @@ pub fn do_reftypes_analysis(
         }
         debug!(
             "move from {:?} (range {:?}) to {:?} (range {:?}) at inst {:?}",
-            src, dst, src_range, dst_range, iix
+            src, src_range, dst, dst_range, iix
         );
         range_pairs.push((dst_range, src_range));
     }

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -1801,11 +1801,11 @@ impl SortedRangeFragIxs {
             .binary_search_by(|&ix| {
                 let frag = &fenv[ix];
                 if pt < frag.first {
-                    Ordering::Less
+                    Ordering::Greater
                 } else if pt >= frag.first && pt <= frag.last {
                     Ordering::Equal
                 } else {
-                    Ordering::Greater
+                    Ordering::Less
                 }
             })
             .is_ok()
@@ -1878,11 +1878,11 @@ impl SortedRangeFrags {
         self.frags
             .binary_search_by(|frag| {
                 if pt < frag.first {
-                    Ordering::Less
+                    Ordering::Greater
                 } else if pt >= frag.first && pt <= frag.last {
                     Ordering::Equal
                 } else {
-                    Ordering::Greater
+                    Ordering::Less
                 }
             })
             .is_ok()


### PR DESCRIPTION
When converting the search-for-range-at-given-point logic from simple
linear search to binary search, I got the comparison polarity of
the closure to `binary_search_by` backward (i.e., `Ordering::Less` means
the probed location is less than the target, not vice-versa). Things
worked with simple tests where moves only had one frag per reg, but
broke on a real test.

Curiously, fuzzing didn't find this; it's possible the test generation
got stuck in a corner and didn't generate any interesting tests. I also
wasn't able to reproduce with a minimized test case. I can confirm this
does fix compilation of the `wasm/gc/anyref.js` JIT-test in SpiderMonkey
using the Cranelift/aarch64 backend, however.