### PR TITLE
Version 0.0.28.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc"
-version = "0.0.27"
+version = "0.0.28"
 authors = ["The Regalloc.rs Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
This PR bumps the version to 0.0.28 to allow us to make a new release with the bugfixes in #86 and #85 included.

Putting this up for review now to reduce latency but I'll rebase-merge it once #86 lands.