### PR TITLE
Rework the initial retypeness-analysis to be more production-suitable.

### DIFF
--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -280,11 +280,6 @@ pub fn run_analysis<F: Function>(
             func,
             &reg_vecs_and_bounds,
             &estimated_frequencies,
-            reg_to_ranges_maps.as_ref().unwrap(),
-            &rlr_env,
-            &vlr_env,
-            &frag_env,
-            /* want_ranges = */ client_wants_stackmaps,
         ))
     } else {
         None
@@ -297,6 +292,7 @@ pub fn run_analysis<F: Function>(
         do_reftypes_analysis(
             &mut rlr_env,
             &mut vlr_env,
+            &frag_env,
             reg_to_ranges_maps.as_ref().unwrap(), /* safe because of logic just above */
             &move_info.as_ref().unwrap(),         /* ditto */
             reftype_class,

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -1,60 +1,92 @@
 //! Performs a simple taint analysis, to find all live ranges that are reftyped.
 
 use crate::data_structures::{
-    MoveInfo, MoveInfoElem, RangeId, RealRange, RealRangeIx, RegClass, RegToRangesMaps, TypedIxVec,
-    VirtualRange, VirtualRangeIx, VirtualReg,
+    InstPoint, Map, MoveInfo, MoveInfoElem, RangeFrag, RangeFragIx, RangeId, RealRange,
+    RealRangeIx, Reg, RegClass, RegToRangesMaps, TypedIxVec, VirtualRange, VirtualRangeIx,
+    VirtualReg,
 };
-use crate::sparse_set::SparseSet;
+use crate::sparse_set::{SparseSet, SparseSetU};
 
 use log::debug;
+use smallvec::SmallVec;
 
 pub fn do_reftypes_analysis(
     // From dataflow/liveness analysis.  Modified by setting their is_ref bit.
     rlr_env: &mut TypedIxVec<RealRangeIx, RealRange>,
     vlr_env: &mut TypedIxVec<VirtualRangeIx, VirtualRange>,
     // From dataflow analysis
+    frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
     reg_to_ranges_maps: &RegToRangesMaps,
     move_info: &MoveInfo,
     // As supplied by the client
     reftype_class: RegClass,
     reftyped_vregs: &Vec<VirtualReg>,
 ) {
+    // Helper: find the RangeId (RealRange or VirtualRange) for a register at an InstPoint.
+    let find_range_id_for_reg = |pt: InstPoint, reg: Reg| -> RangeId {
+        if reg.is_real() {
+            for &rlrix in &reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize] {
+                if rlr_env[rlrix].sorted_frags.contains_pt(frag_env, pt) {
+                    return RangeId::new_real(rlrix);
+                }
+            }
+        } else {
+            for &vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize] {
+                if vlr_env[vlrix].sorted_frags.contains_pt(pt) {
+                    return RangeId::new_virtual(vlrix);
+                }
+            }
+        }
+        panic!("do_reftypes_analysis::find_range_for_reg: can't find range");
+    };
+
     // The game here is: starting with `reftyped_vregs`, find *all* the VirtualRanges and
-    // RealRanges to which that refness can flow, via instructions which the client's `is_move`
+    // RealRanges to which refness can flow, via instructions which the client's `is_move`
     // function considers to be moves.
 
-    // We have `move_info`, which tells us which regs (both real and virtual) are connected by
-    // moves.  However, that's not directly useful -- we need to know which *ranges* are
-    // connected by moves.  So first, convert `move_info` into a set of range-pairs.
+    // This is done in three stages:
+    //
+    // (1) Create a mapping from source (virtual or real) ranges to sets of destination ranges.
+    //     We have `move_info`, which tells us which (virtual or real) regs are connected by
+    //     moves.  However, that's not directly useful -- we need to know which *ranges* are
+    //     connected by moves.  `move_info` as supplied helpfully indicates both source and
+    //     destination regs and ranges, so we can simply use that.
+    //
+    // (2) Similarly, convert `reftyped_vregs` into a set of reftyped ranges by consulting
+    //     `reg_to_ranges_maps`.
+    //
+    // (3) Compute the transitive closure of (1) starting from the ranges in (2).  This is done
+    //     by a depth first search of the graph implied by (1).
 
-    let mut range_pairs = Vec::<(RangeId, RangeId)>::new(); // (DST, SRC)
-
-    debug!("do_reftypes_analysis starting");
-
-    for &MoveInfoElem {
-        dst,
-        src,
-        src_range,
-        dst_range,
-        iix,
-        ..
-    } in &move_info.moves
-    {
+    // ====== Compute (1) above ======
+    // Each entry in `succ` maps from `src` to a `SparseSet<dsts>`, so to speak.  That is, for
+    // `d1`, `d2`, etc, in `dsts`, the function contains moves `d1 := src`, `d2 := src`, etc.
+    let mut succ = Map::<RangeId, SparseSetU<[RangeId; 4]>>::default();
+    for &MoveInfoElem { dst, src, iix, .. } in &move_info.moves {
         // Don't waste time processing moves which can't possibly be of reftyped values.
+        debug_assert!(dst.get_class() == src.get_class());
         if dst.get_class() != reftype_class {
             continue;
         }
+        let src_range = find_range_id_for_reg(InstPoint::new_use(iix), src);
+        let dst_range = find_range_id_for_reg(InstPoint::new_def(iix), dst);
         debug!(
             "move from {:?} (range {:?}) to {:?} (range {:?}) at inst {:?}",
             src, src_range, dst, dst_range, iix
         );
-        range_pairs.push((dst_range, src_range));
+        match succ.get_mut(&src_range) {
+            Some(dst_ranges) => dst_ranges.insert(dst_range),
+            None => {
+                // Re `; 4`: we expect most copies copy a register to only a few destinations.
+                let mut dst_ranges = SparseSetU::<[RangeId; 4]>::empty();
+                dst_ranges.insert(dst_range);
+                let r = succ.insert(src_range, dst_ranges);
+                assert!(r.is_none());
+            }
+        }
     }
 
-    // We have to hand the range-pairs that must be a superset of the moves that could possibly
-    // carry reftyped values.  Now compute the starting set of reftyped virtual ranges.  This
-    // can serve as the starting value for the following fixpoint iteration.
-
+    // ====== Compute (2) above ======
     let mut reftyped_ranges = SparseSet::<RangeId>::empty();
     for vreg in reftyped_vregs {
         // If this fails, the client has been telling is that some virtual reg is reftyped, yet
@@ -67,44 +99,38 @@ pub fn do_reftypes_analysis(
         }
     }
 
-    // Now, finally, compute the fixpoint resulting from repeatedly mapping `reftyped_ranges`
-    // through `range_pairs`. XXXX this looks dangerously expensive .. reimplement.
-    //
-    // Later .. this is overkill.  All that is needed is a DFS of the directed graph in which
-    // the nodes are the union of the RealRange(Ixs) and the VirtualRange(Ixs), and whose edges
-    // are exactly what we computed into `range_pairs`.  This graph then needs to be searched
-    // from each root in `reftyped_ranges`.
-    loop {
-        let card_before = reftyped_ranges.card();
-
-        for (dst_lr_id, src_lr_id) in &range_pairs {
-            if reftyped_ranges.contains(*src_lr_id) {
-                debug!("reftyped range {:?} -> {:?}", src_lr_id, dst_lr_id);
-                reftyped_ranges.insert(*dst_lr_id);
+    // ====== Compute (3) above ======
+    // Almost all chains of copies will be less than 64 long, I would guess.
+    let mut stack = SmallVec::<[RangeId; 64]>::new();
+    let mut visited = reftyped_ranges.clone();
+    for start_point_range in reftyped_ranges.iter() {
+        // Perform DFS from `start_point_range`.
+        stack.clear();
+        stack.push(*start_point_range);
+        while let Some(src_range) = stack.pop() {
+            visited.insert(src_range);
+            if let Some(dst_ranges) = succ.get(&src_range) {
+                for dst_range in dst_ranges.iter() {
+                    if !visited.contains(*dst_range) {
+                        stack.push(*dst_range);
+                    }
+                }
             }
-        }
-
-        let card_after = reftyped_ranges.card();
-        if card_after == card_before {
-            // Since we're only ever adding items to `reftyped_ranges`, and it has set
-            // semantics, checking that the cardinality is unchanged is an adequate check for
-            // having reached a (the minimal?) fixpoint.
-            break;
         }
     }
 
     // Finally, annotate rlr_env/vlr_env with the results of the analysis.  (That was the whole
     // point!)
-    for lr_id in reftyped_ranges.iter() {
-        if lr_id.is_real() {
-            let rrange = &mut rlr_env[lr_id.to_real()];
+    for range in visited.iter() {
+        if range.is_real() {
+            let rrange = &mut rlr_env[range.to_real()];
             debug_assert!(!rrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", lr_id.to_real());
+            debug!(" -> rrange {:?} is reffy", range.to_real());
             rrange.is_ref = true;
         } else {
-            let vrange = &mut vlr_env[lr_id.to_virtual()];
+            let vrange = &mut vlr_env[range.to_virtual()];
             debug_assert!(!vrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", lr_id.to_virtual());
+            debug!(" -> rrange {:?} is reffy", range.to_virtual());
             vrange.is_ref = true;
         }
     }

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -2136,16 +2136,14 @@ pub struct RegToRangesMaps {
 //=============================================================================
 // Some auxiliary/miscellaneous data structures that are useful: MoveInfo
 
-// MoveInfo holds info about registers connected by moves.  For each, we record the source and
-// destination of the move, the insn performing the move, and the estimated execution frequency
-// of the containing block.  The moves are not presented in any particular order, but they are
-// duplicate-free in that each such instruction will be listed only once.
+// `MoveInfoElem` holds info about the two registers connected a move: the source and destination
+// of the move, the insn performing the move, and the estimated execution frequency of the
+// containing block.  In `MoveInfo`, the moves are not presented in any particular order, but
+// they are duplicate-free in that each such instruction will be listed only once.
 
 pub struct MoveInfoElem {
     pub dst: Reg,
-    pub dst_range: RangeId, // possibly RangeId::invalid_value() if not requested
     pub src: Reg,
-    pub src_range: RangeId, // possibly RangeId::invalid_value() if not requested
     pub iix: InstIx,
     pub est_freq: u32,
 }


### PR DESCRIPTION
`analysis_reftypes.rs` was hacked up a couple months back as a temporary (correct but
inefficient) analysis, so as to facilitate getting the rest of the reftypes work under way.
This commit reworks it to be more suitable for production use.  There are two changes:

* `fn do_reftypes_analysis` now performs the core refness-propagation analysis by performing a
  depth-first search on a graph (induced indirectly by move instructions in the input).
  Previously, it used a fixpoint mechanism, but that was unnecessarily general.  This probably
  changes the big-O cost of the overall analysis for the better.

* `fn collect_move_info` no longer computes `RangeId`s for the moves that it collects.  This
  work has been moved into `fn do_reftypes_analysis`.  Bear in mind that inputs that have been
  translated from SSA with large (or large numbers of) phi nodes, can have large numbers of
  moves.  There are three benefits to this change, therefore:

  - it localises that complexity at the only place that needs it, viz, refness analysis, rather
    than having it in the main dataflow analysis area (`analysis_dataflow.rs`).

  - it avoids the space overhead of storing those `RangeId`s in struct `MoveInfoElem` in cases
    where reftypes support is not requested by the client.

  - even when reftypes support is requested by the client, those `RangeId`s are only required
    for moves of reftyped values, so computing them for all moves is potential wasted work.

Measurements on non-reftyped-using inputs show no compiler cost regression; indeed a small win
in instruction count and bytes of around 0.1% in both cases.  I have no large test inputs with
which to quantify the effects on reftype-intensive cases.