### PR TITLE
Control flow analysis, `fn calc_preord_and_postord`: remove use of re…

### DIFF
--- a/lib/src/sparse_set.rs
+++ b/lib/src/sparse_set.rs
@@ -11,7 +11,10 @@ use std::hash::Hash;
 //=============================================================================
 // SparseSet
 
+// Handy wrappers around `SparseSetU`, if you don't want to have to guess at an "optimal"
+// in-line size.
 pub type SparseSet<T> = SparseSetU<[T; 12]>;
+//pub type SparseSetIter<'a, T> = SparseSetUIter<'a, [T; 12]>; // No use case yet
 
 // Implementation: for small, unordered but no dups
 


### PR DESCRIPTION
…cursion in the depth-first

search, and use an explicit stack instead.  The recursion depth could in the worst case be
proportional to the number of blocks in the function, which is dependent on the supplied input
(in particular, wasm).  Hence the use of recursion could be interpreted as a hazard in some
production scenarios.

Also a ridealong comment-only change for `SparseSet`.