### PR TITLE
Bump version to 0.0.29 for release.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc"
-version = "0.0.28"
+version = "0.0.29"
 authors = ["The Regalloc.rs Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Seems it's about time to roll another release to incorporate the latest performance wins into Cranelift!

I'll publish to crates.io once this PR is merged.