### PR TITLE
Use `SmallVec` inside `RegToRangesMaps::rreg_to_rlrs_map`.  This redu…

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1884,7 +1884,7 @@ pub fn compute_reg_to_ranges_maps<F: Function>(
 
     // Same for the real live ranges.
     let mut rreg_approx_frag_counts = vec![0u8; num_rregs];
-    let mut rreg_to_rlrs_map = vec![Vec::<RealRangeIx>::new(); num_rregs];
+    let mut rreg_to_rlrs_map = vec![SmallVec::<[RealRangeIx; 6]>::new(); num_rregs];
     for (rlr, n) in rlr_env.iter().zip(0..) {
         let rlrix = RealRangeIx::new(n);
         let rreg: RealReg = rlr.rreg;

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -2107,9 +2107,10 @@ pub struct RegToRangesMaps {
     // This maps RealReg indices to the set of RealRangeIxs for that RealReg.  Valid indices are
     // real register indices for all non-sanitised real regs; that is,
     // 0 .. RealRegUniverse::allocable, for ".." having the Rust meaning.  The Vecs of
-    // RealRangeIxs are duplicate-free.  They are Vec rather than SmallVec because they are often
-    // large, so SmallVec would just be a disadvantage here.
-    pub rreg_to_rlrs_map: Vec</*real reg ix, */ Vec<RealRangeIx>>,
+    // RealRangeIxs are duplicate-free.  The SmallVec capacity of 6 was chosen after quite
+    // some profiling, of CL/x64/newBE compiling ZenGarden.wasm -- a huge input, with many
+    // relatively small functions.  Profiling was performed in August 2020, using Valgrind/DHAT.
+    pub rreg_to_rlrs_map: Vec</*real reg ix, */ SmallVec<[RealRangeIx; 6]>>,
 
     // This maps VirtualReg indices to the set of VirtualRangeIxs for that VirtualReg.  Valid
     // indices are 0 .. Function::get_num_vregs().  For functions mostly translated from SSA,


### PR DESCRIPTION
…ces the malloc count by

almost 5% for CL/x64/newBE compiling ZenGarden.wasm, and appears to be performance neutral on
other test cases.