### PR TITLE
Do not use an enum for SpillSlot, and simplify Writable constraints + import pretty printing

### DIFF
--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -902,9 +902,9 @@ impl Reg {
 /// create a distinction, at the Rust type level, between a plain "register"
 /// and a "writable register".
 ///
-/// There is nothing that ensures that Writable<..> is only wrapped around Reg
-/// and its variants (`RealReg`, `VirtualReg`).  That however is its intended
-/// and currently its only use.
+/// Only structs that implement the `WritableBase` trait can be wrapped with
+/// `Writable`. These are the Reg, RealReg and VirtualReg data structures only,
+/// since `WritableBase` is not exposed to end users.
 ///
 /// Writable<..> can be used by the client to ensure that, internally, it only
 /// generates instructions that write to registers that should be written. The

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -918,11 +918,21 @@ impl Reg {
 /// error.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct Writable<R: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug> {
+pub struct Writable<R: WritableBase> {
     reg: R,
 }
 
-impl<R: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug> Writable<R> {
+/// Set of requirements for types that can be wrapped in Writable.
+pub trait WritableBase:
+    Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug
+{
+}
+
+impl WritableBase for Reg {}
+impl WritableBase for RealReg {}
+impl WritableBase for VirtualReg {}
+
+impl<R: WritableBase> Writable<R> {
     /// Create a Writable<R> from an R. The client should carefully audit where
     /// it calls this constructor to ensure correctness (see `Writable<..>`
     /// struct documentation).
@@ -939,26 +949,23 @@ impl<R: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug> Wr
     pub fn map<F, U>(&self, f: F) -> Writable<U>
     where
         F: Fn(R) -> U,
-        U: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug,
+        U: WritableBase,
     {
         Writable { reg: f(self.reg) }
     }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum SpillSlot {
-    SpillSlot(u32),
-}
+pub struct SpillSlot(u32);
+
 impl SpillSlot {
     #[inline(always)]
     pub fn new(n: u32) -> Self {
-        SpillSlot::SpillSlot(n)
+        Self(n)
     }
     #[inline(always)]
     pub fn get(self) -> u32 {
-        match self {
-            SpillSlot::SpillSlot(n) => n,
-        }
+        self.0
     }
     #[inline(always)]
     pub fn get_usize(self) -> usize {
@@ -972,6 +979,7 @@ impl SpillSlot {
         SpillSlot::new(self.get() + num_slots)
     }
 }
+
 impl fmt::Debug for SpillSlot {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "S{}", self.get())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,6 +26,7 @@ mod checker;
 mod data_structures;
 mod inst_stream;
 mod linear_scan;
+mod pretty_print;
 mod reg_maps;
 mod snapshot;
 mod sparse_set;
@@ -36,6 +37,9 @@ use std::default;
 use std::{borrow::Cow, fmt};
 
 // Stuff that is defined by the library
+
+// Pretty-printing utilities.
+pub use crate::pretty_print::*;
 
 // Sets and maps of things.  We can refine these later; but for now the
 // interface needs some way to speak about them, so let's use the
@@ -55,7 +59,7 @@ pub use crate::data_structures::Reg;
 pub use crate::data_structures::RealReg;
 pub use crate::data_structures::VirtualReg;
 
-pub use crate::data_structures::{Writable, WritableBase};
+pub use crate::data_structures::Writable;
 
 pub use crate::data_structures::NUM_REG_CLASSES;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::data_structures::Reg;
 pub use crate::data_structures::RealReg;
 pub use crate::data_structures::VirtualReg;
 
-pub use crate::data_structures::Writable;
+pub use crate::data_structures::{Writable, WritableBase};
 
 pub use crate::data_structures::NUM_REG_CLASSES;
 

--- a/lib/src/pretty_print.rs
+++ b/lib/src/pretty_print.rs
@@ -1,0 +1,56 @@
+//! Pretty-printing for the main data structures.
+
+use crate::data_structures::WritableBase;
+use crate::{RealRegUniverse, Reg, Writable};
+
+/// A trait for printing instruction bits and pieces, with the the ability to take a
+/// contextualising `RealRegUniverse` that is used to give proper names to registers.
+pub trait PrettyPrint {
+    /// Return a string that shows the implementing object in context of the given
+    /// `RealRegUniverse`, if provided.
+    fn show_rru(&self, maybe_reg_universe: Option<&RealRegUniverse>) -> String;
+}
+
+/// Same as `PrettyPrint`, but can also take a size hint into account to specialize the displayed
+/// string.
+pub trait PrettyPrintSized: PrettyPrint {
+    /// The same as |show_rru|, but with an optional hint giving a size in bytes. Its
+    /// interpretation is object-dependent, and it is intended to pass around enough information to
+    /// facilitate printing sub-parts of real registers correctly. Objects may ignore size hints
+    /// that are irrelevant to them.
+    ///
+    /// The default implementation ignores the size hint.
+    fn show_rru_sized(&self, maybe_reg_universe: Option<&RealRegUniverse>, _size: u8) -> String {
+        self.show_rru(maybe_reg_universe)
+    }
+}
+
+impl PrettyPrint for Reg {
+    fn show_rru(&self, maybe_reg_universe: Option<&RealRegUniverse>) -> String {
+        if self.is_real() {
+            if let Some(rru) = maybe_reg_universe {
+                let reg_ix = self.get_index();
+                assert!(
+                    reg_ix < rru.regs.len(),
+                    "unknown real register with index {:?}",
+                    reg_ix
+                );
+                return rru.regs[reg_ix].1.to_string();
+            }
+        }
+        // The reg is virtual, or we have no universe. Be generic.
+        format!("%{:?}", self)
+    }
+}
+
+impl<R: PrettyPrint + WritableBase> PrettyPrint for Writable<R> {
+    fn show_rru(&self, maybe_reg_universe: Option<&RealRegUniverse>) -> String {
+        self.to_reg().show_rru(maybe_reg_universe)
+    }
+}
+
+impl<R: PrettyPrintSized + WritableBase> PrettyPrintSized for Writable<R> {
+    fn show_rru_sized(&self, maybe_reg_universe: Option<&RealRegUniverse>, size: u8) -> String {
+        self.to_reg().show_rru_sized(maybe_reg_universe, size)
+    }
+}


### PR DESCRIPTION
No change in functionality here.

This will require changes in Cranelift too (so Cranelift gets rid of its own ShowWithRRU trait), but fortunately these changes are non-breaking, since the two traits can coexist.