### PR TITLE
Add `is_included_in_clobbers` to public API.

### DIFF
--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1792,7 +1792,9 @@ pub fn alloc_main<F: Function>(
     let mut reg_vecs = RegVecs::new(/*sanitized=*/ false);
     let mut dummy_bounds = RegVecBounds::new();
     for insn in &final_insns {
-        add_raw_reg_vecs_for_insn::<F>(insn, &mut reg_vecs, &mut dummy_bounds);
+        if func.is_included_in_clobbers(insn) {
+            add_raw_reg_vecs_for_insn::<F>(insn, &mut reg_vecs, &mut dummy_bounds);
+        }
     }
     for reg in reg_vecs.defs.iter().chain(reg_vecs.mods.iter()) {
         assert!(reg.is_real());

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -224,6 +224,25 @@ pub trait Function {
     /// Determine whether an instruction is a return instruction.
     fn is_ret(&self, insn: InstIx) -> bool;
 
+    /// Determine whether an instruction should be considered while computing
+    /// the set of registers that need to be saved/restored in the function's
+    /// prologue/epilogue, that is, the registers returned in
+    /// `clobbered_registers` in `RegAllocResult`.  computation. Only
+    /// instructions for which this function returns `true` will be used to
+    /// compute that set.
+    ///
+    /// One reason that a client might *not* want an instruction to be included
+    /// would be if it can handle the clobbers some other way: for example,
+    /// ABI-support code might exclude call instructions' defs and mods from the
+    /// clobber set, because (given the callee has same ABI as the caller) the
+    /// registers possibly written by the callee are all registers that the
+    /// caller is also allowed to clobber (not save/restore in
+    /// prologue/epilogue).
+    fn is_included_in_clobbers(&self, _insn: &Self::Inst) -> bool {
+        // Default impl includes all instructions.
+        true
+    }
+
     // --------------------------
     // Instruction register slots
     // --------------------------

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -724,6 +724,7 @@ fn set_registers<F: Function>(
             mapper.set_use(vreg, rreg);
         }
 
+        let included_in_clobbers = func.is_included_in_clobbers(func.get_insn(iix));
         if mention_set.is_mod() {
             if let Some(prev_rreg) = mapper.lookup_use(vreg) {
                 debug_assert_eq!(prev_rreg, rreg, "different use allocs for {:?}", vreg);
@@ -734,7 +735,9 @@ fn set_registers<F: Function>(
 
             mapper.set_use(vreg, rreg);
             mapper.set_def(vreg, rreg);
-            clobbered_registers.insert(rreg);
+            if included_in_clobbers {
+                clobbered_registers.insert(rreg);
+            }
         }
 
         if mention_set.is_def() {
@@ -743,7 +746,9 @@ fn set_registers<F: Function>(
             }
 
             mapper.set_def(vreg, rreg);
-            clobbered_registers.insert(rreg);
+            if included_in_clobbers {
+                clobbered_registers.insert(rreg);
+            }
         }
     }
 


### PR DESCRIPTION
This allows the client to request that certain instructions' register
writes be excluded from the returned clobbered-register set. This may be
useful when the client can handle such writes in other ways: for
example, by reasoning directly about ABIs. (One common case is that if a
caller and callee have the same ABI, then the call instruction in the
caller need not be included in the clobber set that is used to generate
the caller's clobber-saves, because any register that the callee
clobbers is also allowed to be clobbered by the caller.)

See also bytecodealliance/regalloc.rs#2228 and bytecodealliance/regalloc.rs#2254.