### PR TITLE
Release 0.0.31.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["The Regalloc.rs Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Time for another release so that we can pull the latest goodness into Cranelift! In particular, we need #100 in order to handle an AArch64 ABI fix.