### PR TITLE
`get_range_frags_for_block`: improve cost handling for 'modifies' ref…

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1004,8 +1004,11 @@ fn get_range_frags_for_block<F: Function>(
                 // not listed in `livein`, since otherwise `state` would have an entry for it.
                 None => panic!("get_range_frags_for_block: fail #2"),
                 Some(ref mut pf) => {
-                    // This the first or subsequent modify after a write.
-                    pf.num_mentions = plus1(pf.num_mentions);
+                    // This the first or subsequent modify after a write.  Add two to the
+                    // mentions count, as that reflects the implied spill cost increment more
+                    // accurately than just adding one: if we spill the live range in which this
+                    // ends up, we'll generate both a reload and a spill instruction.
+                    pf.num_mentions = plus1(plus1(pf.num_mentions));
                     let new_last = InstPoint::new_def(iix);
                     debug_assert!(pf.last <= new_last);
                     pf.last = new_last;


### PR DESCRIPTION
…erences to a reg.

One of the tasks of `fn get_range_frags_for_block` is to count the number of times each virtual
reg is mentioned, so as to give a basis for computation of spill costs.  It adds one for a
'use' or 'def' reference, which is reasonable.  But it also currently adds one for a 'mod'
reference, which is a bit misleading, given that if we spill a live range containing a 'mod'
reference, we'll have to generate a reload before the referencing insn and a spill afterwards.
So really we should increment the menioned-count by two, not one.  This patch makes that change.