### PR TITLE
Refactor analysis

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1321,7 +1321,7 @@ fn deref_and_compress_sorted_range_frag_ixs(
 
     if num_frags == 1 {
         // Nothing we can do.  Shortcut.
-        res.frags.push(frag_env[sorted_frag_ixs[0]].clone());
+        res.push(frag_env[sorted_frag_ixs[0]].clone());
         *stats_num_vfrags_compressed += 1;
         return res;
     }
@@ -1349,13 +1349,13 @@ fn deref_and_compress_sorted_range_frag_ixs(
         // emit (s, e)
         if s == e {
             // Can't compress this one
-            res.frags.push(frag_env[sorted_frag_ixs[s]].clone());
+            res.push(frag_env[sorted_frag_ixs[s]].clone());
         } else {
             let compressed_frag = RangeFrag {
                 first: frag_env[sorted_frag_ixs[s]].first,
                 last: frag_env[sorted_frag_ixs[e]].last,
             };
-            res.frags.push(compressed_frag);
+            res.push(compressed_frag);
         }
         // move on
         s = e + 1;
@@ -1363,7 +1363,7 @@ fn deref_and_compress_sorted_range_frag_ixs(
     }
     // END merge this frag sequence as much as possible
 
-    *stats_num_vfrags_compressed += res.frags.len();
+    *stats_num_vfrags_compressed += res.len();
     res
 }
 
@@ -1861,7 +1861,7 @@ pub(crate) fn compute_reg_to_ranges_maps<F: Function>(
         let vreg_index = vlr.vreg.get_index();
         vreg_to_vlrs_map[vreg_index].push(VirtualRangeIx::new(vlr_ix));
 
-        let vlr_num_frags = vlr.sorted_frags.frags.len();
+        let vlr_num_frags = vlr.sorted_frags.len();
         add_u8_usize_saturate_to_u8(&mut vreg_approx_frag_counts[vreg_index], vlr_num_frags);
     }
 

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -48,10 +48,6 @@ pub enum AnalysisError {
     /// Implementation limits exceeded.  The incoming function is too big.  It
     /// may contain at most 1 million basic blocks and 16 million instructions.
     ImplementationLimitsExceeded,
-
-    /// Currently LSRA can't generate stackmaps, but the client has requested LSRA *and*
-    /// stackmaps.
-    LSRACantDoStackmaps,
 }
 
 impl ToString for AnalysisError {
@@ -77,10 +73,6 @@ impl ToString for AnalysisError {
             AnalysisError::UnreachableBlocks => "at least one block is unreachable".to_string(),
             AnalysisError::ImplementationLimitsExceeded => {
                 "implementation limits exceeded (more than 1 million blocks or 16 million insns)"
-                    .to_string()
-            }
-            AnalysisError::LSRACantDoStackmaps => {
-                "LSRA *and* stackmap creation requested; but this combination is not yet supported"
                     .to_string()
             }
         }

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -258,29 +258,25 @@ pub fn run_analysis<F: Function>(
     // Now a bit of auxiliary info collection, which isn't really either control- or data-flow
     // analysis.
 
-    // For BT and/or reftypes, we'll also need the reg-to-ranges maps.
-    let reg_to_ranges_maps =
+    // For BT and/or reftypes, we'll also need the reg-to-ranges maps and information about moves.
+    let (reg_to_ranges_maps, move_info) =
         if client_wants_stackmaps || algorithm == AlgorithmWithDefaults::Backtracking {
-            Some(compute_reg_to_ranges_maps(
-                func,
-                &reg_universe,
-                &rlr_env,
-                &vlr_env,
-            ))
+            (
+                Some(compute_reg_to_ranges_maps(
+                    func,
+                    &reg_universe,
+                    &rlr_env,
+                    &vlr_env,
+                )),
+                Some(collect_move_info(
+                    func,
+                    &reg_vecs_and_bounds,
+                    &estimated_frequencies,
+                )),
+            )
         } else {
-            None
+            (None, None)
         };
-
-    // For BT and/or reftypes, we'll also need information about moves.
-    let move_info = if client_wants_stackmaps || algorithm == AlgorithmWithDefaults::Backtracking {
-        Some(collect_move_info(
-            func,
-            &reg_vecs_and_bounds,
-            &estimated_frequencies,
-        ))
-    } else {
-        None
-    };
 
     info!("  run_analysis: end liveness analysis");
 

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -130,10 +130,8 @@ pub fn run_analysis<F: Function>(
         func.insns().len()
     );
 
-    // LSRA can't do reftypes yet.  That should have been checked at the top level already.
-    if client_wants_stackmaps {
-        assert!(algorithm != AlgorithmWithDefaults::LinearScan);
-    }
+    // LSRA uses its own analysis.
+    assert!(!client_wants_stackmaps || algorithm != AlgorithmWithDefaults::LinearScan);
 
     info!("  run_analysis: begin control flow analysis");
 

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -10,7 +10,7 @@ use crate::sparse_set::{SparseSet, SparseSetU};
 use log::debug;
 use smallvec::SmallVec;
 
-pub fn do_reftypes_analysis(
+pub(crate) fn do_reftypes_analysis(
     // From dataflow/liveness analysis.  Modified by setting their is_ref bit.
     rlr_env: &mut TypedIxVec<RealRangeIx, RealRange>,
     vlr_env: &mut TypedIxVec<VirtualRangeIx, VirtualRange>,
@@ -62,7 +62,7 @@ pub fn do_reftypes_analysis(
     // Each entry in `succ` maps from `src` to a `SparseSet<dsts>`, so to speak.  That is, for
     // `d1`, `d2`, etc, in `dsts`, the function contains moves `d1 := src`, `d2 := src`, etc.
     let mut succ = Map::<RangeId, SparseSetU<[RangeId; 4]>>::default();
-    for &MoveInfoElem { dst, src, iix, .. } in &move_info.moves {
+    for &MoveInfoElem { dst, src, iix, .. } in move_info.iter() {
         // Don't waste time processing moves which can't possibly be of reftyped values.
         debug_assert!(dst.get_class() == src.get_class());
         if dst.get_class() != reftype_class {

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -131,7 +131,7 @@ impl ToFromU32 for VirtualRangeIx {
 // it also may change the spill costs for some of the VLRs in `vlr_env` to
 // better reflect the spill cost situation in the presence of coalescing.
 #[inline(never)]
-pub fn do_coalescing_analysis<F: Function>(
+pub(crate) fn do_coalescing_analysis<F: Function>(
     func: &F,
     univ: &RealRegUniverse,
     rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
@@ -529,7 +529,7 @@ pub fn do_coalescing_analysis<F: Function>(
         iix,
         est_freq,
         ..
-    } in &move_info.moves
+    } in move_info.iter()
     {
         debug!(
             "connected by moves: {:?} {:?} <- {:?} (est_freq {})",

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -260,7 +260,7 @@ pub fn do_coalescing_analysis<F: Function>(
         };
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[*rreg_no as usize];
         for rlrix in rlrixs {
-            for fix in &rlr_env[*rlrix].sorted_frags.frag_ixs {
+            for fix in rlr_env[*rlrix].sorted_frags.iter() {
                 let frag = &frag_env[*fix];
                 many_frags_info.sorted_firsts.push((frag.first, *rlrix));
                 many_frags_info.sorted_lasts.push((frag.last, *rlrix));
@@ -421,7 +421,7 @@ pub fn do_coalescing_analysis<F: Function>(
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
         for rlrix in rlrixs {
             let frags = &rlr_env[*rlrix].sorted_frags;
-            for fix in &frags.frag_ixs {
+            for fix in frags.iter() {
                 let frag = &frag_env[*fix];
                 if frag.last == point_to_find {
                     return Some(*rlrix);
@@ -461,7 +461,7 @@ pub fn do_coalescing_analysis<F: Function>(
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
         for rlrix in rlrixs {
             let frags = &rlr_env[*rlrix].sorted_frags;
-            for fix in &frags.frag_ixs {
+            for fix in frags.iter() {
                 let frag = &frag_env[*fix];
                 if frag.first == point_to_find {
                     return Some(*rlrix);

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -306,7 +306,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         };
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[*vreg_no as usize];
         for vlrix in vlrixs {
-            for frag in &vlr_env[*vlrix].sorted_frags.frags {
+            for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 many_frags_info.sorted_firsts.push((frag.first, *vlrix));
                 many_frags_info.sorted_lasts.push((frag.last, *vlrix));
             }
@@ -344,7 +344,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         let vreg_no = vreg.get_index();
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
         for vlrix in vlrixs {
-            for frag in &vlr_env[*vlrix].sorted_frags.frags {
+            for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 if frag.last == point_to_find {
                     return Some(*vlrix);
                 }
@@ -352,6 +352,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         }
         None
     };
+
     let doesVRegHaveLastUseAt = |vreg: VirtualReg, iix: InstIx| -> Option<VirtualRangeIx> {
         let point_to_find = InstPoint::new_use(iix);
         let vreg_no = vreg.get_index();
@@ -382,7 +383,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         let vreg_no = vreg.get_index();
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
         for vlrix in vlrixs {
-            for frag in &vlr_env[*vlrix].sorted_frags.frags {
+            for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 if frag.first == point_to_find {
                     return Some(*vlrix);
                 }
@@ -390,6 +391,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         }
         None
     };
+
     let doesVRegHaveFirstDefAt = |vreg: VirtualReg, iix: InstIx| -> Option<VirtualRangeIx> {
         let point_to_find = InstPoint::new_def(iix);
         let vreg_no = vreg.get_index();
@@ -430,6 +432,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         }
         None
     };
+
     let doesRRegHaveLastUseAt = |rreg: RealReg, iix: InstIx| -> Option<RealRangeIx> {
         let point_to_find = InstPoint::new_use(iix);
         let rreg_no = rreg.get_index();
@@ -470,6 +473,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         }
         None
     };
+
     let doesRRegHaveFirstDefAt = |rreg: RealReg, iix: InstIx| -> Option<RealRangeIx> {
         let point_to_find = InstPoint::new_def(iix);
         let rreg_no = rreg.get_index();

--- a/lib/src/bt_commitment_map.rs
+++ b/lib/src/bt_commitment_map.rs
@@ -109,13 +109,13 @@ impl CommitmentMap {
         }
     }
 
-    pub fn add_indirect(
+    pub(crate) fn add_indirect(
         &mut self,
         to_add_frags: &SortedRangeFragIxs,
         to_add_lr_id: RangeId,
         frag_env: &TypedIxVec<RangeFragIx, RangeFrag>,
     ) {
-        for fix in &to_add_frags.frag_ixs {
+        for fix in to_add_frags.iter() {
             let to_add = RangeFragAndRangeId::new(frag_env[*fix].clone(), to_add_lr_id);
             let added = self.tree.insert(
                 to_add,

--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -2161,23 +2161,32 @@ pub struct RegToRangesMaps {
     pub many_frags_thresh: usize,
 }
 
-//=============================================================================
-// Some auxiliary/miscellaneous data structures that are useful: MoveInfo
-
-// `MoveInfoElem` holds info about the two registers connected a move: the source and destination
-// of the move, the insn performing the move, and the estimated execution frequency of the
-// containing block.  In `MoveInfo`, the moves are not presented in any particular order, but
-// they are duplicate-free in that each such instruction will be listed only once.
-
-pub struct MoveInfoElem {
-    pub dst: Reg,
-    pub src: Reg,
-    pub iix: InstIx,
-    pub est_freq: u32,
+/// `MoveInfoElem` holds info about the two registers connected a move: the source and destination
+/// of the move, the instruction performing the move, and the estimated execution frequency of the
+/// containing block.
+pub(crate) struct MoveInfoElem {
+    pub(crate) dst: Reg,
+    pub(crate) src: Reg,
+    pub(crate) iix: InstIx,
+    pub(crate) est_freq: u32,
 }
 
-pub struct MoveInfo {
-    pub moves: Vec<MoveInfoElem>,
+/// Vector of `MoveInfoElem`, presented in no particular order, but duplicate-free in that each
+/// move instruction will be listed only once.
+pub(crate) struct MoveInfo(Vec<MoveInfoElem>);
+
+impl MoveInfo {
+    pub(crate) fn new(move_info: Vec<MoveInfoElem>) -> Self {
+        Self(move_info)
+    }
+}
+
+impl Deref for MoveInfo {
+    type Target = Vec<MoveInfoElem>;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 // Something that can be either a VirtualRangeIx or a RealRangeIx, whilst still being 32 bits


### PR DESCRIPTION
Small refactorings I saw while wanting to work on linear scan. This is mostly using more idiomatic Rust in a few places, using doc comments, wrapping comment lines at 100 chars, simplifying a few patterns, trying to encapsulate a few structs a bit better and enhance their ergonomics (e.g. `MoveInfo`). No changes in functionality here. Commit messages contain more details about the nature of each change.

@julian-seward1 and/or @cfallin, PTAL. Thanks!