### PR TITLE
Checker: make sure that ref values live over a safepoint must be reloaded

### DIFF
--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -130,7 +130,7 @@ pub fn do_reftypes_analysis(
         } else {
             let vrange = &mut vlr_env[range.to_virtual()];
             debug_assert!(!vrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", range.to_virtual());
+            debug!(" -> vrange {:?} is reffy", range.to_virtual());
             vrange.is_ref = true;
         }
     }

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -316,10 +316,17 @@ impl CheckerState {
                 }
             }
         }
+        // Mark registers holding reference values as unknown, forcing the need for a reload around
+        // the safepoint.
+        for (_, val) in &mut self.reg_values {
+            if let &mut CheckerValue::Reg(_, true) = val {
+                *val = CheckerValue::Unknown;
+            }
+        }
     }
 
     /// Update according to instruction.
-    pub(crate) fn update(&mut self, inst: &Inst) {
+    fn update(&mut self, inst: &Inst) {
         match inst {
             &Inst::Op {
                 ref defs_orig,

--- a/tests/stackmap.rat
+++ b/tests/stackmap.rat
@@ -1,0 +1,11 @@
+reftype_start = 1
+v0 = I32
+v1_ref = I32
+real = real I32 2
+
+b0:
+    imm     v0, 42
+    makeref v1_ref, v0
+    safepoint
+    useref  real, v1_ref
+    finish


### PR DESCRIPTION
Also adds enough testing support so that we can actually run a small
test program with reftypes, as well as a unit test.