### PR TITLE
Tweak the crate/workspace setup so that fuzz binaries are built in root `target/` directory.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 
 [workspace]
 members = [
-    "lib"
+    "lib",
+    "fuzz"
 ]
 
 [[bin]]
@@ -31,3 +32,8 @@ bincode = "1.2.1"
 
 [profile.release]
 debug = true
+
+[profile.release.package.minira-util-fuzz]
+debug = true
+debug-assertions = true
+overflow-checks = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,35 +13,38 @@ libfuzzer-sys = "0.3"
 minira-util = { path = ".." }
 regalloc = { path = "../lib", features = ["fuzzing"] }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "bt"
 path = "fuzz_targets/bt.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "bt_differential"
 path = "fuzz_targets/bt_differential.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "lsra"
 path = "fuzz_targets/lsra.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "lsra_differential"
 path = "fuzz_targets/lsra_differential.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "validator"
 path = "fuzz_targets/validator.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "parser"
 path = "fuzz_targets/parser.rs"
-
-[profile.release]
-debug = true
-debug-assertions = true
-overflow-checks = true
+test = false
+doc = false

--- a/fuzz/fuzz_targets/bt.rs
+++ b/fuzz/fuzz_targets/bt.rs
@@ -49,7 +49,8 @@ fuzz_target!(|func: ir::Func| {
     };
 
     let sri = func.get_stackmap_request();
-    let ra_result = regalloc::allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts);
+    let ra_result =
+        regalloc::allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts);
 
     match ra_result {
         Ok(result) => {

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -57,26 +57,33 @@ pub enum AnalysisError {
 impl ToString for AnalysisError {
     fn to_string(&self) -> String {
         match self {
-      AnalysisError::CriticalEdge { from, to } => {
-        format!("critical edge detected, from {:?} to {:?}", from, to)
-      }
-      AnalysisError::EntryLiveinValues(regs) => {
-        let regs_string = regs.iter().map(|reg| format!("{:?}", reg)).collect::<Vec<_>>().join(", ");
-        format!("entry block has love-in value not present in function liveins: {}", regs_string)
-      }
-      AnalysisError::IllegalRealReg(reg) => {
-        format!("instructions mention real register {:?}, which either isn't defined in the register universe, or is a 'suggested_scratch' register", reg)
-      }
-      AnalysisError::UnreachableBlocks => {
-        "at least one block is unreachable".to_string()
-      }
-      AnalysisError::ImplementationLimitsExceeded => {
-        "implementation limits exceeded (more than 1 million blocks or 16 million insns)".to_string()
-      }
-      AnalysisError::LSRACantDoStackmaps => {
-        "LSRA *and* stackmap creation requested; but this combination is not yet supported".to_string()
-      }
-    }
+            AnalysisError::CriticalEdge { from, to } => {
+                format!("critical edge detected, from {:?} to {:?}", from, to)
+            }
+            AnalysisError::EntryLiveinValues(regs) => {
+                let regs_string = regs
+                    .iter()
+                    .map(|reg| format!("{:?}", reg))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "entry block has love-in value not present in function liveins: {}",
+                    regs_string
+                )
+            }
+            AnalysisError::IllegalRealReg(reg) => {
+                format!("instructions mention real register {:?}, which either isn't defined in the register universe, or is a 'suggested_scratch' register", reg)
+            }
+            AnalysisError::UnreachableBlocks => "at least one block is unreachable".to_string(),
+            AnalysisError::ImplementationLimitsExceeded => {
+                "implementation limits exceeded (more than 1 million blocks or 16 million insns)"
+                    .to_string()
+            }
+            AnalysisError::LSRACantDoStackmaps => {
+                "LSRA *and* stackmap creation requested; but this combination is not yet supported"
+                    .to_string()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Because the fuzzing crate was previously in its own Cargo workspace, its
build process placed its binaries in `fuzz/target/...`. Other
infrastructure (such as OSS-Fuzz) doesn't expect this. This PR instead
makes the fuzzing crate an ordinary part of the main workspace, and
tweaks the build-option overrides to work with this new setup. Followup
to #106.

Sorry for the tedium of little tweaks here!