### PR TITLE
Re-enable checker for LSRA

### DIFF
--- a/bin/fuzzing.rs
+++ b/bin/fuzzing.rs
@@ -431,7 +431,7 @@ impl Arbitrary for Func {
             name: "funk".to_string(),
             entry,
             num_virtual_regs: (num_virtual_regs + num_reftyped_regs) as u32,
-            reftype_reg_start: num_virtual_regs as u32,
+            reftype_reg_start: Some(num_virtual_regs as u32),
             insns: insts,
             blocks,
         })

--- a/bin/parser.rs
+++ b/bin/parser.rs
@@ -13,6 +13,8 @@ use regalloc::{Reg, RegClass};
 
 use crate::test_framework::*;
 
+pub(crate) const REFTYPE_START: &'static str = "reftype_start";
+
 #[derive(Debug)]
 pub enum ParseError {
     IoError(io::Error),
@@ -428,9 +430,9 @@ pub fn parse_content(func_name: &str, content: &str) -> ParseResult<Func> {
     loop {
         name = parser.read_ident()?;
         let c = parser.read_char()?;
-        if &name == "reftype_start" && c == '=' {
+        if &name == REFTYPE_START && c == '=' {
             let index = parser.read_int()?;
-            parser.func.reftype_reg_start = index;
+            parser.func.reftype_reg_start = Some(index);
         } else if c == '=' {
             // variable declaration.
             let real_or_class = parser.read_ident()?;

--- a/tests/fuzz_stackmap.rat
+++ b/tests/fuzz_stackmap.rat
@@ -1,3 +1,4 @@
+reftype_start = 0
 v0I = I32
 v2I = I32
 v13I = I32

--- a/tests/fuzz_stackmap2.rat
+++ b/tests/fuzz_stackmap2.rat
@@ -1,3 +1,4 @@
+reftype_start = 0
 v0I = I32
 v2I = I32
 v4I = I32

--- a/tests/fuzz_stackmap3.rat
+++ b/tests/fuzz_stackmap3.rat
@@ -1,3 +1,4 @@
+reftype_start = 0
 v0I = I32
 v1I = I32
 v2I = I32


### PR DESCRIPTION
I've been fortunate; there were no new LSRA failures since the checker had been deactivated.

This also adds two small things:

- add a check that the checker is eventually run, otherwise it's useless. We could remove this part, since it might fiddle with fuzzing in surprising ways, e.g. if fuzzing finds a bug somewhere between the creation of `CheckerContext` and `CheckerContext::run()`, it may panic while it panics because of this change.
- don't mix "having no reftype_start" with "all vregs are reftypes". Use a real `Option` to denote the presence or absence of this configuration line. Also renders the special annotation when running from the fuzzer: this should help with extracting test cases from the fuzzer output.