### PR TITLE
Support reference types in linear scan

### DIFF
--- a/bin/minira.rs
+++ b/bin/minira.rs
@@ -343,7 +343,8 @@ mod test_utils {
             .allocate(opts.clone())
             .expect("generic allocator failed!");
 
-        let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
+        let sri = func.get_stackmap_request();
+        let result = allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts)
             .unwrap_or_else(|err| {
                 panic!("allocation failed: {}", err);
             });
@@ -373,6 +374,7 @@ mod test_utils {
             RunStage::BeforeRegalloc,
         );
         func.print("BEFORE", &None);
+        let sri = func.get_stackmap_request();
 
         let opts = Options {
             run_checker: false,
@@ -389,8 +391,9 @@ mod test_utils {
                 .allocate(opts.clone())
                 .expect("generic allocator failed!");
 
-            let result = allocate_registers_with_opts(&mut func, &reg_universe, None, opts.clone())
-                .expect("regalloc failure");
+            let result =
+                allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts.clone())
+                    .expect("regalloc failure");
 
             func.update_from_alloc(result);
             func.print("AFTER", &None);
@@ -777,4 +780,20 @@ fn lsra_analysis_fuzz2() {
 #[test]
 fn lsra_sort_fixed() {
     test_utils::check_lsra("lsra_sort_fixed", 5, 5);
+}
+
+#[test]
+fn bt_fuzz_stackmap() {
+    test_utils::check_bt("stackmap", 5, 5);
+    test_utils::check_bt("fuzz_stackmap", 5, 5);
+    test_utils::check_bt("fuzz_stackmap2", 5, 5);
+    test_utils::check_bt("fuzz_stackmap3", 5, 5);
+}
+
+#[test]
+fn lsra_fuzz_stackmap() {
+    test_utils::check_lsra("stackmap", 5, 5);
+    test_utils::check_lsra("fuzz_stackmap", 5, 5);
+    test_utils::check_lsra("fuzz_stackmap2", 5, 5);
+    test_utils::check_lsra("fuzz_stackmap3", 5, 5);
 }

--- a/fuzz/fuzz_targets/lsra.rs
+++ b/fuzz/fuzz_targets/lsra.rs
@@ -4,34 +4,57 @@ use libfuzzer_sys::fuzz_target;
 use minira::{self, test_framework as ir};
 use regalloc;
 
+static mut COUNTER_GEN: usize = 0;
+static mut COUNTER_OK: usize = 0;
+
 fuzz_target!(|func: ir::Func| {
+    let (num_gen, num_ok) = unsafe {
+        COUNTER_GEN += 1;
+        (COUNTER_GEN, COUNTER_OK)
+    };
+
+    println!(
+        "=== status: #ok/#total: {}/{} == {} ",
+        num_ok,
+        num_gen,
+        100.0 * (num_ok as f64) / (num_gen as f64)
+    );
+
     let mut func = func;
+    let original_func = func.clone();
 
     // Add one register to be used as a scratch.
     let num_regs = minira::fuzzing::NUM_REAL_REGS_PER_RC as usize + 1;
     let reg_universe = ir::make_universe(num_regs, num_regs);
 
-    let mut rendered = String::new();
-    func.render("func:", &mut rendered).unwrap();
-    println!("{}", rendered);
-
+    let sri = func.get_stackmap_request();
     let result = match regalloc::allocate_registers_with_opts(
         &mut func,
         &reg_universe,
-        None,
+        sri.as_ref(),
         regalloc::Options {
             run_checker: true,
             algorithm: regalloc::Algorithm::LinearScan(Default::default()),
         },
     ) {
-        Ok(result) => result,
+        Ok(result) => {
+            unsafe {
+                COUNTER_OK += 1;
+            }
+            result
+        }
         Err(err) => {
             if let regalloc::RegAllocError::RegChecker(_) = &err {
+                let mut rendered = String::new();
+                original_func.render("func:", &mut rendered).unwrap();
+                println!("{}", rendered);
+
                 panic!(format!(
                     "fuzz_lsra_differential.rs: checker error: {:?}",
                     err
                 ));
             }
+
             println!("allocation error: {}", err);
             return;
         }

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -75,7 +75,11 @@ impl ToString for AnalysisError {
                 )
             }
             AnalysisError::IllegalRealReg(reg) => {
-                format!("instructions mention real register {:?}, which either isn't defined in the register universe, or is a 'suggested_scratch' register", reg)
+                format!(
+                    "instructions mention real register {:?}, which either isn't defined in the
+                    register universe, or is a 'suggested_scratch' register",
+                    reg
+                )
             }
             AnalysisError::UnreachableBlocks => "at least one block is unreachable".to_string(),
             AnalysisError::ImplementationLimitsExceeded => {

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -6,9 +6,82 @@ use crate::data_structures::{
     VirtualReg,
 };
 use crate::sparse_set::{SparseSet, SparseSetU};
+use std::{fmt, hash::Hash};
 
 use log::debug;
 use smallvec::SmallVec;
+
+/// Parameters to configure a reftype analysis.
+pub(crate) trait ReftypeAnalysis {
+    /// An unified representation of a range, for both virtual and real ranges.
+    type RangeId: Eq + Hash + Copy + fmt::Debug;
+
+    /// Find the RangeId related to `reg` and containing `pt`. May panic if the point isn't
+    /// actually present in any range of the given register.
+    fn find_range_id_for_reg(&self, pt: InstPoint, reg: Reg) -> Self::RangeId;
+
+    /// Add all the ranges associated to this vreg into the set of reftyped ranges.
+    fn insert_reffy_ranges(&self, vreg: VirtualReg, set: &mut SparseSet<Self::RangeId>);
+
+    /// Mark a given RangeId as being reffy.
+    fn mark_reffy(&mut self, range_id: &Self::RangeId);
+}
+
+/// Implementation of the reftype analysis for the backtracking algorithm.
+struct BacktrackingReftypeAnalysis<'a> {
+    rlr_env: &'a mut TypedIxVec<RealRangeIx, RealRange>,
+    vlr_env: &'a mut TypedIxVec<VirtualRangeIx, VirtualRange>,
+    frag_env: &'a TypedIxVec<RangeFragIx, RangeFrag>,
+    reg_to_ranges_maps: &'a RegToRangesMaps,
+}
+
+impl<'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'a> {
+    type RangeId = RangeId;
+
+    #[inline(always)]
+    fn find_range_id_for_reg(&self, pt: InstPoint, reg: Reg) -> Self::RangeId {
+        if reg.is_real() {
+            for &rlrix in &self.reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize] {
+                if self.rlr_env[rlrix]
+                    .sorted_frags
+                    .contains_pt(self.frag_env, pt)
+                {
+                    return RangeId::new_real(rlrix);
+                }
+            }
+        } else {
+            for &vlrix in &self.reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize] {
+                if self.vlr_env[vlrix].sorted_frags.contains_pt(pt) {
+                    return RangeId::new_virtual(vlrix);
+                }
+            }
+        }
+        panic!("do_reftypes_analysis::find_range_for_reg: can't find range");
+    }
+
+    #[inline(always)]
+    fn mark_reffy(&mut self, range: &Self::RangeId) {
+        if range.is_real() {
+            let rrange = &mut self.rlr_env[range.to_real()];
+            debug_assert!(!rrange.is_ref);
+            debug!(" -> rrange {:?} is reffy", range.to_real());
+            rrange.is_ref = true;
+        } else {
+            let vrange = &mut self.vlr_env[range.to_virtual()];
+            debug_assert!(!vrange.is_ref);
+            debug!(" -> rrange {:?} is reffy", range.to_virtual());
+            vrange.is_ref = true;
+        }
+    }
+
+    #[inline(always)]
+    fn insert_reffy_ranges(&self, vreg: VirtualReg, set: &mut SparseSet<Self::RangeId>) {
+        for vlr_ix in &self.reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()] {
+            debug!("range {:?} is reffy due to reffy vreg {:?}", vlr_ix, vreg);
+            set.insert(RangeId::new_virtual(*vlr_ix));
+        }
+    }
+}
 
 pub(crate) fn do_reftypes_analysis(
     // From dataflow/liveness analysis.  Modified by setting their is_ref bit.
@@ -22,24 +95,22 @@ pub(crate) fn do_reftypes_analysis(
     reftype_class: RegClass,
     reftyped_vregs: &Vec<VirtualReg>,
 ) {
-    // Helper: find the RangeId (RealRange or VirtualRange) for a register at an InstPoint.
-    let find_range_id_for_reg = |pt: InstPoint, reg: Reg| -> RangeId {
-        if reg.is_real() {
-            for &rlrix in &reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize] {
-                if rlr_env[rlrix].sorted_frags.contains_pt(frag_env, pt) {
-                    return RangeId::new_real(rlrix);
-                }
-            }
-        } else {
-            for &vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize] {
-                if vlr_env[vlrix].sorted_frags.contains_pt(pt) {
-                    return RangeId::new_virtual(vlrix);
-                }
-            }
-        }
-        panic!("do_reftypes_analysis::find_range_for_reg: can't find range");
+    let mut analysis = BacktrackingReftypeAnalysis {
+        rlr_env,
+        vlr_env,
+        frag_env,
+        reg_to_ranges_maps,
     };
+    core_reftypes_analysis(&mut analysis, move_info, reftype_class, reftyped_vregs);
+}
 
+pub(crate) fn core_reftypes_analysis<RA: ReftypeAnalysis>(
+    analysis: &mut RA,
+    move_info: &MoveInfo,
+    // As supplied by the client
+    reftype_class: RegClass,
+    reftyped_vregs: &Vec<VirtualReg>,
+) {
     // The game here is: starting with `reftyped_vregs`, find *all* the VirtualRanges and
     // RealRanges to which refness can flow, via instructions which the client's `is_move`
     // function considers to be moves.
@@ -61,15 +132,15 @@ pub(crate) fn do_reftypes_analysis(
     // ====== Compute (1) above ======
     // Each entry in `succ` maps from `src` to a `SparseSet<dsts>`, so to speak.  That is, for
     // `d1`, `d2`, etc, in `dsts`, the function contains moves `d1 := src`, `d2 := src`, etc.
-    let mut succ = Map::<RangeId, SparseSetU<[RangeId; 4]>>::default();
+    let mut succ = Map::<RA::RangeId, SparseSetU<[RA::RangeId; 4]>>::default();
     for &MoveInfoElem { dst, src, iix, .. } in move_info.iter() {
         // Don't waste time processing moves which can't possibly be of reftyped values.
         debug_assert!(dst.get_class() == src.get_class());
         if dst.get_class() != reftype_class {
             continue;
         }
-        let src_range = find_range_id_for_reg(InstPoint::new_use(iix), src);
-        let dst_range = find_range_id_for_reg(InstPoint::new_def(iix), dst);
+        let src_range = analysis.find_range_id_for_reg(InstPoint::new_use(iix), src);
+        let dst_range = analysis.find_range_id_for_reg(InstPoint::new_def(iix), dst);
         debug!(
             "move from {:?} (range {:?}) to {:?} (range {:?}) at inst {:?}",
             src, src_range, dst, dst_range, iix
@@ -78,7 +149,7 @@ pub(crate) fn do_reftypes_analysis(
             Some(dst_ranges) => dst_ranges.insert(dst_range),
             None => {
                 // Re `; 4`: we expect most copies copy a register to only a few destinations.
-                let mut dst_ranges = SparseSetU::<[RangeId; 4]>::empty();
+                let mut dst_ranges = SparseSetU::<[RA::RangeId; 4]>::empty();
                 dst_ranges.insert(dst_range);
                 let r = succ.insert(src_range, dst_ranges);
                 assert!(r.is_none());
@@ -87,21 +158,18 @@ pub(crate) fn do_reftypes_analysis(
     }
 
     // ====== Compute (2) above ======
-    let mut reftyped_ranges = SparseSet::<RangeId>::empty();
+    let mut reftyped_ranges = SparseSet::<RA::RangeId>::empty();
     for vreg in reftyped_vregs {
         // If this fails, the client has been telling is that some virtual reg is reftyped, yet
         // it doesn't belong to the class of regs that it claims can carry refs.  So the client
         // is buggy.
         debug_assert!(vreg.get_class() == reftype_class);
-        for vlrix in &reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()] {
-            debug!("range {:?} is reffy due to reffy vreg {:?}", vlrix, vreg);
-            reftyped_ranges.insert(RangeId::new_virtual(*vlrix));
-        }
+        analysis.insert_reffy_ranges(*vreg, &mut reftyped_ranges);
     }
 
     // ====== Compute (3) above ======
     // Almost all chains of copies will be less than 64 long, I would guess.
-    let mut stack = SmallVec::<[RangeId; 64]>::new();
+    let mut stack = SmallVec::<[RA::RangeId; 64]>::new();
     let mut visited = reftyped_ranges.clone();
     for start_point_range in reftyped_ranges.iter() {
         // Perform DFS from `start_point_range`.
@@ -119,19 +187,8 @@ pub(crate) fn do_reftypes_analysis(
         }
     }
 
-    // Finally, annotate rlr_env/vlr_env with the results of the analysis.  (That was the whole
-    // point!)
+    // Finally, annotate the results of the analysis.
     for range in visited.iter() {
-        if range.is_real() {
-            let rrange = &mut rlr_env[range.to_real()];
-            debug_assert!(!rrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", range.to_real());
-            rrange.is_ref = true;
-        } else {
-            let vrange = &mut vlr_env[range.to_virtual()];
-            debug_assert!(!vrange.is_ref);
-            debug!(" -> vrange {:?} is reffy", range.to_virtual());
-            vrange.is_ref = true;
-        }
+        analysis.mark_reffy(range);
     }
 }

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1720,14 +1720,13 @@ pub fn alloc_main<F: Function>(
 
     let final_insns_and_targetmap_and_new_safepoints__or_err = edit_inst_stream(
         func,
-        &safepoint_insns,
         spills_n_reloads,
         &iixs_to_nop_out,
         frag_map,
         &reg_universe,
         use_checker,
+        stackmap_request,
         &stackmaps[..],
-        &reftyped_vregs[..],
     );
 
     // ======== END Create final instruction stream ========

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -1334,7 +1334,7 @@ pub fn alloc_main<F: Function>(
                 assert!(src_reg.is_virtual() && dst_reg.is_virtual());
                 let dst_vreg: VirtualReg = dst_reg.to_virtual_reg();
                 let src_vreg: VirtualReg = src_reg.to_virtual_reg();
-                let bridge_eef = est_freqs[sri.bix];
+                let bridge_eef = est_freqs.cost(sri.bix);
                 match sri.kind {
                     BridgeKind::RtoU => {
                         // Reload-to-Use bridge.  Hint that we want to be

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -55,11 +55,11 @@
 
 #![allow(dead_code)]
 
-use crate::analysis_data_flow::get_san_reg_sets_for_insn;
 use crate::data_structures::{
     BlockIx, InstIx, Map, RealReg, RealRegUniverse, Reg, RegSets, SpillSlot, VirtualReg, Writable,
 };
 use crate::inst_stream::{ExtPoint, InstExtPoint, InstToInsertAndExtPoint};
+use crate::{analysis_data_flow::get_san_reg_sets_for_insn, StackmapRequestInfo};
 use crate::{Function, RegUsageMapper};
 
 use rustc_hash::FxHashSet;
@@ -631,6 +631,12 @@ pub(crate) struct CheckerContext {
     checker_inst_map: Map<InstExtPoint, Vec<Inst>>,
 }
 
+/// Full infromation needed by the checker for checking reference types.
+pub(crate) struct CheckerStackmapInfo<'a> {
+    pub(crate) request: &'a StackmapRequestInfo,
+    pub(crate) stackmaps: &'a [Vec<SpillSlot>],
+}
+
 impl CheckerContext {
     /// Create a new checker context for the given function, which is about to be edited with the
     /// given instruction insertions.
@@ -638,11 +644,8 @@ impl CheckerContext {
         f: &F,
         ru: &RealRegUniverse,
         insts_to_add: &Vec<InstToInsertAndExtPoint>,
-        safepoint_insns: &[InstIx],
-        stackmaps: &[Vec<SpillSlot>],
-        reftyped_vregs: &[VirtualReg],
+        stackmap_info: Option<CheckerStackmapInfo>,
     ) -> CheckerContext {
-        assert!(safepoint_insns.len() == stackmaps.len());
         let mut checker_inst_map: Map<InstExtPoint, Vec<Inst>> = Map::default();
         for &InstToInsertAndExtPoint { ref inst, ref iep } in insts_to_add {
             let checker_insts = checker_inst_map
@@ -650,18 +653,31 @@ impl CheckerContext {
                 .or_insert_with(|| vec![]);
             checker_insts.push(inst.to_checker_inst());
         }
-        for (iix, slots) in safepoint_insns.iter().zip(stackmaps.iter()) {
-            let iep = InstExtPoint::new(*iix, ExtPoint::Use);
-            let mut slots = slots.clone();
-            slots.sort();
-            checker_inst_map
-                .entry(iep)
-                .or_insert_with(|| vec![])
-                .push(Inst::Safepoint {
-                    inst_ix: *iix,
-                    slots,
-                });
-        }
+
+        let reftyped_vregs = if let Some(info) = stackmap_info {
+            assert!(info.request.safepoint_insns.len() == info.stackmaps.len());
+            for (iix, slots) in info
+                .request
+                .safepoint_insns
+                .iter()
+                .zip(info.stackmaps.iter())
+            {
+                let iep = InstExtPoint::new(*iix, ExtPoint::Use);
+                let mut slots = slots.clone();
+                slots.sort();
+                checker_inst_map
+                    .entry(iep)
+                    .or_insert_with(|| vec![])
+                    .push(Inst::Safepoint {
+                        inst_ix: *iix,
+                        slots,
+                    });
+            }
+            info.request.reftyped_vregs.as_slice()
+        } else {
+            &[]
+        };
+
         let checker = Checker::new(f, ru, reftyped_vregs);
         CheckerContext {
             checker,

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -1,8 +1,11 @@
-use crate::checker::Inst as CheckerInst;
 use crate::checker::{CheckerContext, CheckerErrors};
 use crate::data_structures::{
     BlockIx, InstIx, InstPoint, Point, RangeFrag, RealReg, RealRegUniverse, Reg, SpillSlot,
     TypedIxVec, VirtualReg, Writable,
+};
+use crate::{
+    checker::{CheckerStackmapInfo, Inst as CheckerInst},
+    StackmapRequestInfo,
 };
 use crate::{reg_maps::VrangeRegUsageMapper, Function, RegAllocError};
 use log::trace;
@@ -221,21 +224,20 @@ fn map_vregs_to_rregs<F: Function>(
     iixs_to_nop_out: &Vec<InstIx>,
     reg_universe: &RealRegUniverse,
     use_checker: bool,
-    safepoint_insns: &[InstIx],
+    stackmap_request: Option<&StackmapRequestInfo>,
     stackmaps: &[Vec<SpillSlot>],
-    reftyped_vregs: &[VirtualReg],
 ) -> Result<(), CheckerErrors> {
     // Set up checker state, if indicated by our configuration.
     let mut checker: Option<CheckerContext> = None;
     let mut insn_blocks: Vec<BlockIx> = vec![];
     if use_checker {
+        let stackmap_info =
+            stackmap_request.map(|request| CheckerStackmapInfo { request, stackmaps });
         checker = Some(CheckerContext::new(
             func,
             reg_universe,
             insts_to_add,
-            safepoint_insns,
-            stackmaps,
-            reftyped_vregs,
+            stackmap_info,
         ));
         insn_blocks.resize(func.insns().len(), BlockIx::new(0));
         for block_ix in func.blocks() {
@@ -522,7 +524,7 @@ fn map_vregs_to_rregs<F: Function>(
 #[inline(never)]
 pub(crate) fn add_spills_reloads_and_moves<F: Function>(
     func: &mut F,
-    safepoint_insns: &Vec<InstIx>,
+    safepoint_insns: Option<&[InstIx]>,
     mut insts_to_add: Vec<InstToInsertAndExtPoint>,
 ) -> Result<
     (
@@ -533,6 +535,9 @@ pub(crate) fn add_spills_reloads_and_moves<F: Function>(
     ),
     String,
 > {
+    let empty_safepoint_insts = Vec::new();
+    let safepoint_insns = safepoint_insns.unwrap_or(&empty_safepoint_insts);
+
     // Construct the final code by interleaving the mapped code with the the
     // spills, reloads and moves that we have been requested to insert.  To do
     // that requires having the latter sorted by InstPoint.
@@ -630,14 +635,13 @@ pub(crate) fn add_spills_reloads_and_moves<F: Function>(
 #[inline(never)]
 pub(crate) fn edit_inst_stream<F: Function>(
     func: &mut F,
-    safepoint_insns: &Vec<InstIx>,
     insts_to_add: Vec<InstToInsertAndExtPoint>,
     iixs_to_nop_out: &Vec<InstIx>,
     frag_map: Vec<(RangeFrag, VirtualReg, RealReg)>,
     reg_universe: &RealRegUniverse,
     use_checker: bool,
+    stackmap_request: Option<&StackmapRequestInfo>,
     stackmaps: &[Vec<SpillSlot>],
-    reftyped_vregs: &[VirtualReg],
 ) -> Result<
     (
         Vec<F::Inst>,
@@ -654,11 +658,15 @@ pub(crate) fn edit_inst_stream<F: Function>(
         iixs_to_nop_out,
         reg_universe,
         use_checker,
-        &safepoint_insns[..],
+        stackmap_request,
         stackmaps,
-        reftyped_vregs,
     )
     .map_err(|e| RegAllocError::RegChecker(e))?;
-    add_spills_reloads_and_moves(func, safepoint_insns, insts_to_add)
-        .map_err(|e| RegAllocError::Other(e))
+
+    add_spills_reloads_and_moves(
+        func,
+        stackmap_request.map(|request| request.safepoint_insns.as_slice()),
+        insts_to_add,
+    )
+    .map_err(|e| RegAllocError::Other(e))
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -541,11 +541,6 @@ pub fn allocate_registers_with_opts<F: Function>(
         ref safepoint_insns,
     }) = stackmap_info
     {
-        if let Algorithm::LinearScan(_) = opts.algorithm {
-            return Err(RegAllocError::Other(
-                "stackmap request: not currently available for Linear Scan".to_string(),
-            ));
-        }
         if reftype_class != RegClass::I64 && reftype_class != RegClass::I32 {
             return Err(RegAllocError::Other(
                 "stackmap request: invalid reftype_class".to_string(),
@@ -599,7 +594,9 @@ pub fn allocate_registers_with_opts<F: Function>(
         Algorithm::Backtracking(opts) => {
             bt_main::alloc_main(func, rreg_universe, stackmap_info, run_checker, opts)
         }
-        Algorithm::LinearScan(opts) => linear_scan::run(func, rreg_universe, run_checker, opts),
+        Algorithm::LinearScan(opts) => {
+            linear_scan::run(func, rreg_universe, stackmap_info, run_checker, opts)
+        }
     };
 
     info!("================ regalloc.rs: END function ================");

--- a/lib/src/linear_scan/assign_registers.rs
+++ b/lib/src/linear_scan/assign_registers.rs
@@ -1131,6 +1131,7 @@ fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> Int
 
     let vreg = int.vreg;
     let ancestor = int.ancestor;
+    let ref_typed = int.ref_typed;
 
     // Split the register mentions.
     let parent_mentions = state.intervals.get_mut(id).mentions_mut();
@@ -1215,6 +1216,7 @@ fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> Int
         child_end,
         child_mentions,
         child_boundaries,
+        ref_typed,
     );
     child_int.parent = Some(id);
     child_int.ancestor = ancestor;

--- a/tests/fuzz_stackmap2.rat
+++ b/tests/fuzz_stackmap2.rat
@@ -15,7 +15,10 @@ b0:
 
 b1:
     safepoint
-    if_then_else v10I, b0:b0, b0:b0
+    if_then_else v10I, b1b0, b1b0
+
+b1b0:
+    goto b0
 
 b2:
     safepoint
@@ -23,4 +26,7 @@ b2:
     load    r2I, [v0I, 24080239]
     copy    v4I, v0I
     useref  r2I, v13I
-    if_then_else v10I, b0:b0, b0:b0
+    if_then_else v10I, b2b0, b2b0
+
+b2b0:
+    goto b0

--- a/tests/fuzz_stackmap4.rat
+++ b/tests/fuzz_stackmap4.rat
@@ -1,0 +1,19 @@
+reftype_start = 2
+v0I = I32
+v1I = I32
+v2I = I32
+r1I = real I32 1
+r3I = real I32 3
+
+b0:
+    imm     v1I, 1337
+    imm     r3I, 42
+    makeref v2I, v1I
+    useref  v1I, v2I
+    useref  v1I, v2I
+    goto    b1:b1
+
+b1:
+    safepoint
+    useref  v0I, v2I
+    if_then_else r3I, b1:b1, b1:b1


### PR DESCRIPTION
This builds on top of #103 and #109 to add support for reference types to linear scan.

The implementation is slightly different from the one used for backtracking. Backtracking uses a post-processing approach: during analysis, ranges are marked as reffy (i.e. containing reference types); after register allocation, a spill/reload sequence is generated safepoint instruction contained in a reffy range. Since linear scan has support for splitting live ranges, it is able to integrate reference type processing during register assignment: when an interval (~range) is assigned a real register, if it contains a safepoint instruction, then the interval is split and spilled at the safepoint instruction. A single reffy interval `[ start .. safepoint .. end ]` becomes multiple intervals:

- `[ start .. (prev mention .. safepoint)[` allocated to the register; the split point may be in any instruction between just after the previous mention, and just before safepoint,
- `[safepoint .. next mention]`, the interval stays stack allocated until the next real mention of the virtual register
- `[next mention .. end]` is an unallocated interval pushed back into the allocation queue

This is the general scheme. If the safepoint instruction redefines the register (the register is a use and a def of the call), there's no need to spill and reload it across the instruction.
 
This doesn't handle reffy real ranges, since neither Cranelift or the testing framework effectively put reference types in fixed real registers. The LSRA analysis asserts this right now. In the future, we could consider relaxing the regalloc invariants so that only virtual registers can be reffy, and reffy moves involve both a reffy source vreg and reffy target vreg. If so, we could get rid of the reftypes analysis and all the required bookkeeping data structures LSRA has for this.