### PR TITLE
Mark the crate as `#![no_std]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "./bin/minira_lib.rs"
 [dependencies]
 regalloc =  { path = "./lib", features = ["fuzzing", "enable-serde"] }
 arbitrary = { version = "0.4.0", features = ["derive"]}
-rustc-hash = "1.0.1"
+rustc-hash = { version = "1.0.1", default-features = false }
 log = { version = "0.4.8", default-features = false }
 pretty_env_logger = "0.4.0"
 clap = "2.33.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,7 +8,8 @@ description = "Modular register allocation algorithms"
 repository = "https://github.com/bytecodealliance/regalloc.rs"
 
 [dependencies]
-rustc-hash = "1.0.1"
+hashbrown = { version = "0.9.1", default-features = false }
+rustc-hash = { version = "1.0.1", default-features = false }
 log = { version = "0.4.8", default-features = false }
 smallvec = "1.0.0"
 serde = { version = "1.0.94", features = ["derive"], optional = true }
@@ -18,4 +19,4 @@ default = []
 fuzzing = []
 
 # For dependent crates that want to serialize some parts of regalloc.
-enable-serde = ["serde"]
+enable-serde = ["serde", "hashbrown/serde"]

--- a/lib/src/analysis_control_flow.rs
+++ b/lib/src/analysis_control_flow.rs
@@ -1,7 +1,8 @@
 //! Performs control flow analysis.
 
+use alloc::vec::Vec;
 use log::{debug, info};
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::analysis_main::AnalysisError;
 use crate::data_structures::{BlockIx, InstIx, Range, Set, TypedIxVec};

--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1,9 +1,10 @@
 //! Performs dataflow and liveness analysis, including live range construction.
 
+use alloc::{format, string::ToString, vec, vec::Vec};
 use log::{debug, info, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
-use std::cmp::min;
-use std::fmt;
+use core::cmp::min;
+use core::fmt;
 
 use crate::analysis_control_flow::CFGInfo;
 use crate::data_structures::*;
@@ -702,7 +703,7 @@ pub fn calc_livein_and_liveout<F: Function>(
             sum_card_live_in += liveins[bix].card();
             sum_card_live_out += liveouts[bix].card();
         }
-        println!(
+        info!(
             "QQQQ calc_LI/LO: num_evals {}, tot LI {}, tot LO {}",
             num_evals, sum_card_live_in, sum_card_live_out
         );

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -1,5 +1,6 @@
 //! Top level module for all analysis activities.
 
+use alloc::{format, string::{String, ToString}, vec::Vec};
 use log::{debug, info};
 
 use crate::analysis_control_flow::{CFGInfo, InstIxToBlockIxMap};

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -7,6 +7,7 @@ use crate::data_structures::{
 };
 use crate::sparse_set::{SparseSet, SparseSetU};
 
+use alloc::vec::Vec;
 use log::debug;
 use smallvec::SmallVec;
 

--- a/lib/src/avl_tree.rs
+++ b/lib/src/avl_tree.rs
@@ -3,8 +3,9 @@
 //! AVL tree internals are public, so that backtracking.rs can do custom
 //! traversals of the tree as it wishes.
 
+use alloc::vec::Vec;
 use smallvec::SmallVec;
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 //=============================================================================
 // Data structures for AVLTree
@@ -1051,7 +1052,7 @@ impl<T: Clone + PartialOrd> AVLTree<T> {
 #[cfg(test)]
 mod avl_tree_test_utils {
     use crate::data_structures::Set;
-    use std::cmp::Ordering;
+    use core::cmp::Ordering;
 
     // Perform various checks on the tree, and assert if it is not OK.
     pub fn check_tree(
@@ -1223,7 +1224,7 @@ fn test_avl_tree1() {
 
 #[test]
 fn test_avl_tree2() {
-    use std::cmp::Ordering;
+    use core::cmp::Ordering;
 
     // Do some simple testing using a custom comparator, which inverts the order
     // of items in the tree, so as to check custom comparators work right.

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -26,6 +26,7 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
+use alloc::{format, string::{String, ToString}, vec, vec::Vec};
 use log::{debug, info, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
 

--- a/lib/src/bt_commitment_map.rs
+++ b/lib/src/bt_commitment_map.rs
@@ -3,8 +3,8 @@
 
 //! Backtracking allocator: per-real-register commitment maps
 
-use std::cmp::Ordering;
-use std::fmt;
+use core::cmp::Ordering;
+use core::fmt;
 
 use crate::avl_tree::{AVLTree, AVL_NULL};
 use crate::data_structures::{

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -3,10 +3,11 @@
 
 //! Core implementation of the backtracking allocator.
 
+use alloc::{format, string::{String, ToString}, vec, vec::Vec};
 use log::{debug, info, log_enabled, Level};
 use smallvec::SmallVec;
-use std::default;
-use std::fmt;
+use core::default;
+use core::fmt;
 
 use crate::analysis_data_flow::{add_raw_reg_vecs_for_insn, does_inst_use_def_or_mod_reg};
 use crate::analysis_main::{run_analysis, AnalysisInfo};

--- a/lib/src/bt_spillslot_allocator.rs
+++ b/lib/src/bt_spillslot_allocator.rs
@@ -11,6 +11,8 @@ use crate::data_structures::{
 use crate::union_find::UnionFindEquivClasses;
 use crate::Function;
 
+use alloc::{vec, vec::Vec};
+
 //=============================================================================
 // A spill slot allocator.  This could be implemented more simply than it is.
 // The reason for the extra complexity is to support copy-coalescing at the

--- a/lib/src/bt_vlr_priority_queue.rs
+++ b/lib/src/bt_vlr_priority_queue.rs
@@ -3,8 +3,8 @@
 
 //! Backtracking allocator: the as-yet-unallocated VirtualReg LR prio queue.
 
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use alloc::{collections::BinaryHeap, format, string::{String, ToString}, vec, vec::Vec};
+use core::cmp::Ordering;
 
 use crate::data_structures::{TypedIxVec, VirtualRange, VirtualRangeIx};
 

--- a/lib/src/checker.rs
+++ b/lib/src/checker.rs
@@ -62,11 +62,12 @@ use crate::data_structures::{
 use crate::inst_stream::{ExtPoint, InstExtPoint, InstToInsertAndExtPoint};
 use crate::{Function, RegUsageMapper};
 
-use rustc_hash::FxHashSet;
-use std::collections::VecDeque;
-use std::default::Default;
-use std::hash::Hash;
-use std::result::Result;
+use alloc::{collections::VecDeque, vec, vec::Vec};
+use core::default::Default;
+use core::hash::{BuildHasherDefault, Hash};
+use core::result::Result;
+use hashbrown::HashSet;
+use rustc_hash::FxHasher;
 
 use log::debug;
 
@@ -435,7 +436,7 @@ pub(crate) struct Checker {
     bb_in: Map<BlockIx, CheckerState>,
     bb_succs: Map<BlockIx, Vec<BlockIx>>,
     bb_insts: Map<BlockIx, Vec<Inst>>,
-    reftyped_vregs: FxHashSet<VirtualReg>,
+    reftyped_vregs: HashSet<VirtualReg, BuildHasherDefault<FxHasher>>,
     has_run: bool,
 }
 
@@ -490,7 +491,7 @@ impl Checker {
 
         bb_in.insert(f.entry_block(), CheckerState::entry_state(ru));
 
-        let reftyped_vregs = reftyped_vregs.iter().cloned().collect::<FxHashSet<_>>();
+        let reftyped_vregs = reftyped_vregs.iter().cloned().collect::<HashSet<_, _>>();
         Checker {
             bb_entry: f.entry_block(),
             bb_in,

--- a/lib/src/inst_stream.rs
+++ b/lib/src/inst_stream.rs
@@ -7,7 +7,8 @@ use crate::data_structures::{
 use crate::{reg_maps::VrangeRegUsageMapper, Function, RegAllocError};
 use log::trace;
 
-use std::result::Result;
+use alloc::{string::String, vec, vec::Vec};
+use core::result::Result;
 
 //=============================================================================
 // InstToInsert and InstToInsertAndPoint

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,10 @@
 //! to use this library in your own code, you would be well advised to read
 //! the comments in this file very carefully.
 
+#![no_std]
+
+extern crate alloc;
+
 // Make the analysis module public for fuzzing.
 #[cfg(feature = "fuzzing")]
 pub mod analysis_main;
@@ -32,9 +36,10 @@ mod snapshot;
 mod sparse_set;
 mod union_find;
 
+use alloc::{borrow::Cow, string::{String, ToString}, vec, vec::Vec};
 use log::{info, log_enabled, Level};
-use std::default;
-use std::{borrow::Cow, fmt};
+use core::default;
+use core::fmt;
 
 // Stuff that is defined by the library
 

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -10,9 +10,10 @@ use crate::{
     union_find::UnionFind,
     AnalysisError, Function, RealRegUniverse, RegClass, TypedIxVec,
 };
+use alloc::{vec, vec::Vec};
 use log::{debug, info, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
-use std::{fmt, mem};
+use core::{fmt, mem};
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RangeFrag {

--- a/lib/src/linear_scan/assign_registers.rs
+++ b/lib/src/linear_scan/assign_registers.rs
@@ -8,11 +8,12 @@ use crate::{
     VirtualReg, NUM_REG_CLASSES,
 };
 
+use alloc::{collections::BinaryHeap, format, vec::Vec};
 use log::{debug, info, log_enabled, trace, Level};
-use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::collections::BinaryHeap;
-use std::{cmp, cmp::Ordering, fmt};
+use core::{cmp, cmp::Ordering, fmt};
+
+type HashMap<K, V> = hashbrown::HashMap<K, V, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 macro_rules! lsra_assert {
     ($arg:expr) => {
@@ -299,11 +300,11 @@ impl<T: Copy> RegisterMapping<T> {
 }
 
 struct RegisterMappingIter<'a, T: Copy> {
-    iter: std::slice::Iter<'a, (RealReg, T)>,
+    iter: core::slice::Iter<'a, (RealReg, T)>,
     scratch: Option<RealReg>,
 }
 
-impl<'a, T: Copy> std::iter::Iterator for RegisterMappingIter<'a, T> {
+impl<'a, T: Copy> core::iter::Iterator for RegisterMappingIter<'a, T> {
     type Item = &'a (RealReg, T);
     fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next() {
@@ -320,7 +321,7 @@ impl<'a, T: Copy> std::iter::Iterator for RegisterMappingIter<'a, T> {
     }
 }
 
-impl<T> std::ops::Index<RealReg> for RegisterMapping<T> {
+impl<T> core::ops::Index<RealReg> for RegisterMapping<T> {
     type Output = T;
     fn index(&self, rreg: RealReg) -> &Self::Output {
         lsra_assert!(
@@ -329,13 +330,13 @@ impl<T> std::ops::Index<RealReg> for RegisterMapping<T> {
         );
         lsra_assert!(
             Some(rreg) != self.scratch,
-            format!("trying to const-use the scratch of {:?}", rreg.get_class())
+            &format!("trying to const-use the scratch of {:?}", rreg.get_class())
         );
         &self.regs[rreg.get_index() - self.offset].1
     }
 }
 
-impl<T> std::ops::IndexMut<RealReg> for RegisterMapping<T> {
+impl<T> core::ops::IndexMut<RealReg> for RegisterMapping<T> {
     fn index_mut(&mut self, rreg: RealReg) -> &mut Self::Output {
         lsra_assert!(
             rreg.get_class() as usize == self.reg_class_index,
@@ -343,7 +344,7 @@ impl<T> std::ops::IndexMut<RealReg> for RegisterMapping<T> {
         );
         lsra_assert!(
             Some(rreg) != self.scratch,
-            format!("trying to mut-use the scratch of {:?}", rreg.get_class())
+            &format!("trying to mut-use the scratch of {:?}", rreg.get_class())
         );
         &mut self.regs[rreg.get_index() - self.offset].1
     }

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -6,9 +6,9 @@
 
 use log::{info, log_enabled, trace, Level};
 
-use std::default;
-use std::env;
-use std::fmt;
+use alloc::{vec, vec::Vec};
+use core::default;
+use core::fmt;
 
 use crate::inst_stream::{add_spills_reloads_and_moves, InstToInsertAndExtPoint};
 use crate::{
@@ -50,7 +50,7 @@ impl Drop for Statistics {
         if self.only_large && self.num_vregs < 1000 {
             return;
         }
-        println!(
+        info!(
             "stats: {} fixed; {} vreg; {} vranges; {} peak-active; {} peak-inactive, {} direct-alloc; {} total-alloc; {} partial-splits; {} partial-splits-attempts",
             self.num_fixed,
             self.num_vregs,
@@ -90,6 +90,16 @@ pub struct LinearScanOptions {
 
 impl default::Default for LinearScanOptions {
     fn default() -> Self {
+        Self {
+            split_strategy: OptimalSplitStrategy::From,
+            partial_split: false,
+            partial_split_near_end: false,
+            stats: false,
+            large_stats: false,
+        }
+    }
+
+    /*fn default() -> Self {
         // Useful for debugging.
         let optimal_split_strategy = match env::var("LSRA_SPLIT") {
             Ok(s) => match s.as_str() {
@@ -117,7 +127,7 @@ impl default::Default for LinearScanOptions {
             stats,
             large_stats,
         }
-    }
+    }*/
 }
 
 impl fmt::Debug for LinearScanOptions {

--- a/lib/src/linear_scan/resolve_moves.rs
+++ b/lib/src/linear_scan/resolve_moves.rs
@@ -6,10 +6,13 @@ use crate::{
     Function, RealReg, Reg, SpillSlot, TypedIxVec, VirtualReg, Writable,
 };
 
+use alloc::vec::Vec;
 use log::{debug, info, trace};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
-use std::fmt;
+use core::fmt;
+
+type HashMap<K, V> = hashbrown::HashMap<K, V, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+type HashSet<T> = hashbrown::HashSet<T, core::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 fn resolve_moves_in_block<F: Function>(
     func: &F,

--- a/lib/src/pretty_print.rs
+++ b/lib/src/pretty_print.rs
@@ -2,6 +2,7 @@
 
 use crate::data_structures::WritableBase;
 use crate::{RealRegUniverse, Reg, Writable};
+use alloc::{format, string::{String, ToString}};
 
 /// A trait for printing instruction bits and pieces, with the the ability to take a
 /// contextualising `RealRegUniverse` that is used to give proper names to registers.

--- a/lib/src/reg_maps.rs
+++ b/lib/src/reg_maps.rs
@@ -1,6 +1,7 @@
 use crate::{RealReg, RegUsageMapper, VirtualReg};
+use alloc::vec::Vec;
 use smallvec::SmallVec;
-use std::mem;
+use core::mem;
 
 /// This data structure holds the mappings needed to map an instruction's uses, mods and defs from
 /// virtual to real registers.

--- a/lib/src/snapshot.rs
+++ b/lib/src/snapshot.rs
@@ -9,7 +9,7 @@
 
 use crate::data_structures::RegVecs;
 use crate::*;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/lib/src/union_find.rs
+++ b/lib/src/union_find.rs
@@ -4,7 +4,10 @@
 //! An implementation of a fast union-find implementation for "T: ToFromU32" items
 //! in some dense range [0, N-1].
 
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+#[cfg(test)]
+use alloc::vec;
+use core::marker::PhantomData;
 
 //=============================================================================
 // ToFromU32
@@ -544,6 +547,7 @@ impl<'a, T: ToFromU32> Iterator for UnionFindEquivClassLeadersIter<'a, T> {
 
 #[cfg(test)]
 mod union_find_test_utils {
+    use alloc::{vec, vec::Vec};
     use super::UnionFindEquivClasses;
     // Test that the eclass for `elem` is `expected` (modulo ordering).
     pub fn test_eclass(eclasses: &UnionFindEquivClasses<u32>, elem: u32, expected: &Vec<u32>) {


### PR DESCRIPTION
This marks `regalloc` as `#![no_std]`, allowing its usage on platforms that don't have a standard library.

The PR was mostly mechanical, except:

- I use `hashbrown` to provide `HashMap`/`HashSet`. This is the same crate that [the `std` itself uses](https://github.com/rust-lang/rust/blob/18cb4ad3b9440b3ff2ed16976f56889b23811e13/library/std/Cargo.toml#L23).
- I replaced two `println!`s with `info!` (from the `log` crate).
- There are a few usages of `std::env` which I can't replace with an equivalent (see below).

The code in `src/linear_scan/mod.rs` uses `std::env`, apparently for debugging purposes.
At the moment I've just commented out the code, and this PR is marked as draft.

I'd suggest adding something like a `debug-env-override` feature to the crate, which, when enabled, disables `#![no_std]` and makes it use `std::env` as is currently the case.
That's just a suggestion, so let me know if that's suitable or if there's a better solution.
