### PR TITLE
Arena allocation using bumpalo (and hashbrown with custom alloc).

### DIFF
--- a/bin/fuzzing.rs
+++ b/bin/fuzzing.rs
@@ -386,8 +386,8 @@ impl Arbitrary for Func {
             bix: BlockIx::new(0),
         });
 
-        let mut insts = TypedIxVec::new();
-        let mut blocks = TypedIxVec::new();
+        let mut insts = vec![];
+        let mut blocks = vec![];
 
         let mut cur_block = 0;
 
@@ -417,8 +417,8 @@ impl Arbitrary for Func {
             let len = insts.len() - start;
             let block = Block {
                 name: format!("b{}", cur_block),
-                start: InstIx::new(start),
-                len,
+                start: InstIx::new(start as u32),
+                len: len as u32,
                 estimated_execution_frequency: 0,
             };
             blocks.push(block);

--- a/bin/parser.rs
+++ b/bin/parser.rs
@@ -29,7 +29,7 @@ impl From<io::Error> for ParseError {
 
 pub type ParseResult<T> = Result<T, ParseError>;
 
-pub fn parse_file(path: PathBuf) -> ParseResult<Func> {
+pub fn parse_file<'a>(path: PathBuf) -> ParseResult<Func> {
     let basename = path.file_stem().unwrap().to_str().unwrap().to_string();
     let mut file = File::open(path)?;
     let mut content = String::new();
@@ -461,7 +461,7 @@ pub fn parse_content(func_name: &str, content: &str) -> ParseResult<Func> {
 
     // Look for blocks (name already contains the name of the first block).
     loop {
-        let mut insts = Vec::new();
+        let mut insts = vec![];
         let block_name = next_block_name;
 
         // Look for instructions.

--- a/fuzz/fuzz_targets/bt.rs
+++ b/fuzz/fuzz_targets/bt.rs
@@ -49,8 +49,15 @@ fuzz_target!(|func: ir::Func| {
     };
 
     let sri = func.get_stackmap_request();
-    let ra_result =
-        regalloc::allocate_registers_with_opts(&mut func, &reg_universe, sri.as_ref(), opts);
+    let bump = regalloc::Bump::new();
+    let alloc = regalloc::Alloc(&bump);
+    let ra_result = regalloc::allocate_registers_with_opts(
+        &mut func,
+        &reg_universe,
+        sri.as_ref(),
+        opts,
+        &alloc,
+    );
 
     match ra_result {
         Ok(result) => {

--- a/fuzz/fuzz_targets/bt_differential.rs
+++ b/fuzz/fuzz_targets/bt_differential.rs
@@ -23,8 +23,15 @@ fuzz_target!(|func: ir::Func| {
         algorithm: regalloc::Algorithm::Backtracking(Default::default()),
     };
 
-    let result = match regalloc::allocate_registers_with_opts(&mut func, &reg_universe, None, opts)
-    {
+    let bump = regalloc::Bump::new();
+    let alloc = regalloc::Alloc(&bump);
+    let result = match regalloc::allocate_registers_with_opts(
+        &mut func,
+        &reg_universe,
+        None,
+        opts,
+        &alloc,
+    ) {
         Ok(result) => result,
         Err(err) => {
             if let regalloc::RegAllocError::RegChecker(_) = &err {

--- a/fuzz/fuzz_targets/lsra.rs
+++ b/fuzz/fuzz_targets/lsra.rs
@@ -28,6 +28,8 @@ fuzz_target!(|func: ir::Func| {
     let reg_universe = ir::make_universe(num_regs, num_regs);
 
     let sri = func.get_stackmap_request();
+    let bump = regalloc::Bump::new();
+    let alloc = regalloc::Alloc(&bump);
     let result = match regalloc::allocate_registers_with_opts(
         &mut func,
         &reg_universe,
@@ -36,6 +38,7 @@ fuzz_target!(|func: ir::Func| {
             run_checker: true,
             algorithm: regalloc::Algorithm::LinearScan(Default::default()),
         },
+        &alloc,
     ) {
         Ok(result) => {
             unsafe {

--- a/fuzz/fuzz_targets/lsra_differential.rs
+++ b/fuzz/fuzz_targets/lsra_differential.rs
@@ -26,11 +26,14 @@ fuzz_target!(|func: ir::Func| {
     func.render("before allocation", &mut rendered).unwrap();
     println!("{}", rendered);
 
+    let bump = regalloc::Bump::new();
+    let alloc = regalloc::Alloc(&bump);
     let result = match regalloc::allocate_registers(
         &mut func,
         &reg_universe,
         None,
         regalloc::AlgorithmWithDefaults::LinearScan,
+        &alloc,
     ) {
         Ok(result) => result,
         Err(err) => {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ log = { version = "0.4.8", default-features = false }
 smallvec = "1.6.1"
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 bumpalo = { version = "3.4.0", features = ["collections"] }
-hashbrown = { git = "https://github.com/cfallin/hashbrown", rev = "be3ea79b9e87363622111c6fda81ffbff1b30d1e", features = ["raw"] }
+hashbrown = { version = "0.10.0", features = ["raw"] }
 
 [features]
 default = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,6 +12,8 @@ rustc-hash = "1.0.1"
 log = { version = "0.4.8", default-features = false }
 smallvec = "1.6.1"
 serde = { version = "1.0.94", features = ["derive"], optional = true }
+bumpalo = { version = "3.4.0", features = ["collections"] }
+hashbrown = { git = "https://github.com/cfallin/hashbrown", rev = "be3ea79b9e87363622111c6fda81ffbff1b30d1e", features = ["raw"] }
 
 [features]
 default = []

--- a/lib/src/analysis_control_flow.rs
+++ b/lib/src/analysis_control_flow.rs
@@ -7,9 +7,7 @@ use crate::analysis_main::AnalysisError;
 use crate::data_structures::{BlockIx, InstIx, Range, Set, TypedIxVec};
 use crate::sparse_set::{SparseSetU, SparseSetUIter};
 use crate::Function;
-use crate::{Alloc, BumpVec};
-
-use smallvec::SmallVec;
+use crate::{Alloc, BumpSmallVec, BumpVec};
 
 //=============================================================================
 // Debugging config.  Set all these to `false` for normal operation.
@@ -180,7 +178,7 @@ fn calc_preord_and_postord<'a, F: Function>(
 
     // Set up initial state: entry block on the stack, marked as visited, and placed at the
     // start of the pre-ord sequence.
-    let mut stack = SmallVec::<[(BlockIx, SparseSetUIter<[BlockIx; 4]>); 64]>::new();
+    let mut stack = BumpSmallVec::<[(BlockIx, SparseSetUIter<[BlockIx; 4]>); 64]>::new(alloc);
     let bix_entry = func.entry_block();
     visited[bix_entry] = true;
     pre_ord.push(bix_entry);

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -377,7 +377,8 @@ impl<'arena, 'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'arena, 'a> {
     #[inline(always)]
     fn find_range_id_for_reg(&self, pt: InstPoint, reg: Reg) -> Self::RangeId {
         if reg.is_real() {
-            for &rlrix in &self.reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize] {
+            for &rlrix in self.reg_to_ranges_maps.rreg_to_rlrs_map[reg.get_index() as usize].iter()
+            {
                 if self.rlr_env[rlrix]
                     .sorted_frags
                     .contains_pt(self.frag_env, pt)
@@ -386,7 +387,8 @@ impl<'arena, 'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'arena, 'a> {
                 }
             }
         } else {
-            for &vlrix in &self.reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize] {
+            for &vlrix in self.reg_to_ranges_maps.vreg_to_vlrs_map[reg.get_index() as usize].iter()
+            {
                 if self.vlr_env[vlrix].sorted_frags.contains_pt(pt) {
                     return RangeId::new_virtual(vlrix);
                 }
@@ -412,7 +414,7 @@ impl<'arena, 'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'arena, 'a> {
 
     #[inline(always)]
     fn insert_reffy_ranges(&self, vreg: VirtualReg, set: &mut SparseSet<Self::RangeId>) {
-        for vlr_ix in &self.reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()] {
+        for vlr_ix in self.reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()].iter() {
             debug!("range {:?} is reffy due to reffy vreg {:?}", vlr_ix, vreg);
             set.insert(RangeId::new_virtual(*vlr_ix));
         }

--- a/lib/src/analysis_reftypes.rs
+++ b/lib/src/analysis_reftypes.rs
@@ -2,11 +2,10 @@
 
 use crate::data_structures::*;
 use crate::sparse_set::{SparseSet, SparseSetU};
-use crate::{Alloc, BumpMap};
+use crate::{Alloc, BumpMap, BumpSmallVec};
 use std::{fmt, hash::Hash};
 
 use log::debug;
-use smallvec::SmallVec;
 
 /// Parameters to configure a reftype analysis.
 pub(crate) trait ReftypeAnalysis {
@@ -90,7 +89,7 @@ pub(crate) fn core_reftypes_analysis<'a, RA: ReftypeAnalysis>(
 
     // ====== Compute (3) above ======
     // Almost all chains of copies will be less than 64 long, I would guess.
-    let mut stack = SmallVec::<[RA::RangeId; 64]>::new();
+    let mut stack = BumpSmallVec::<[RA::RangeId; 64]>::new(alloc);
     let mut visited = reftyped_ranges.clone();
     for start_point_range in reftyped_ranges.iter() {
         // Perform DFS from `start_point_range`.

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -27,7 +27,6 @@
 #![allow(non_camel_case_types)]
 
 use log::{debug, info, log_enabled, Level};
-use smallvec::{smallvec, SmallVec};
 
 use crate::data_structures::{
     InstIx, InstPoint, Map, MoveInfo, MoveInfoElem, RangeFrag, RangeFragIx, RealRange, RealRangeIx,
@@ -36,6 +35,7 @@ use crate::data_structures::{
 };
 use crate::union_find::{ToFromU32, UnionFind, UnionFindEquivClasses};
 use crate::Alloc;
+use crate::BumpSmallVec;
 use crate::Function;
 
 //=============================================================================
@@ -142,7 +142,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
     move_info: &MoveInfo<'a>,
     alloc: &Alloc<'a>,
 ) -> (
-    TypedIxVec<'a, VirtualRangeIx, SmallVec<[Hint; 8]>>,
+    TypedIxVec<'a, VirtualRangeIx, BumpSmallVec<'a, [Hint; 8]>>,
     UnionFindEquivClasses<'a, VirtualRangeIx>,
     TypedIxVec<'a, InstIx, bool>,
 ) {
@@ -261,7 +261,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
             sorted_lasts: Vec::with_capacity(2 * reg_to_ranges_maps.many_frags_thresh),
         };
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[*rreg_no as usize];
-        for rlrix in rlrixs {
+        for rlrix in rlrixs.iter() {
             for fix in rlr_env[*rlrix].sorted_frags.iter() {
                 let frag = &frag_env[*fix];
                 many_frags_info.sorted_firsts.push((frag.first, *rlrix));
@@ -307,7 +307,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
             sorted_lasts: Vec::with_capacity(2 * reg_to_ranges_maps.many_frags_thresh),
         };
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[*vreg_no as usize];
-        for vlrix in vlrixs {
+        for vlrix in vlrixs.iter() {
             for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 many_frags_info.sorted_firsts.push((frag.first, *vlrix));
                 many_frags_info.sorted_lasts.push((frag.last, *vlrix));
@@ -345,7 +345,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
         let point_to_find = InstPoint::new_use(iix);
         let vreg_no = vreg.get_index();
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
-        for vlrix in vlrixs {
+        for vlrix in vlrixs.iter() {
             for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 if frag.last == point_to_find {
                     return Some(*vlrix);
@@ -384,7 +384,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
         let point_to_find = InstPoint::new_def(iix);
         let vreg_no = vreg.get_index();
         let vlrixs = &reg_to_ranges_maps.vreg_to_vlrs_map[vreg_no];
-        for vlrix in vlrixs {
+        for vlrix in vlrixs.iter() {
             for frag in vlr_env[*vlrix].sorted_frags.iter() {
                 if frag.first == point_to_find {
                     return Some(*vlrix);
@@ -423,7 +423,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
         let point_to_find = InstPoint::new_use(iix);
         let rreg_no = rreg.get_index();
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
-        for rlrix in rlrixs {
+        for rlrix in rlrixs.iter() {
             let frags = &rlr_env[*rlrix].sorted_frags;
             for fix in frags.iter() {
                 let frag = &frag_env[*fix];
@@ -464,7 +464,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
         let point_to_find = InstPoint::new_def(iix);
         let rreg_no = rreg.get_index();
         let rlrixs = &reg_to_ranges_maps.rreg_to_rlrs_map[rreg_no];
-        for rlrix in rlrixs {
+        for rlrix in rlrixs.iter() {
             let frags = &rlr_env[*rlrix].sorted_frags;
             for fix in frags.iter() {
                 let frag = &frag_env[*fix];
@@ -507,8 +507,8 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
     // suppose, for example if there are two identical copy insns at different points on the
     // "boundary" for some VLR.  I don't think it matters though since we're going to rank the
     // hints by strength and then choose at most one.
-    let mut hints = TypedIxVec::<VirtualRangeIx, SmallVec<[Hint; 8]>>::new(alloc);
-    hints.resize(vlr_env.len(), smallvec![]);
+    let mut hints = TypedIxVec::<VirtualRangeIx, BumpSmallVec<[Hint; 8]>>::new(alloc);
+    hints.resize(vlr_env.len(), BumpSmallVec::new(alloc));
 
     // RETURNED TO CALLER
     // A vector that simply records which insns are v-to-v boundary moves, as established by the
@@ -629,7 +629,8 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
     // For the convenience of the allocator core, sort the hints for each VLR so
     // as to move the most preferred to the front.
     for hints_for_one_vlr in hints.iter_mut() {
-        hints_for_one_vlr.sort_by(|h1, h2| h2.get_weight().partial_cmp(&h1.get_weight()).unwrap());
+        hints_for_one_vlr[..]
+            .sort_by(|h1, h2| h2.get_weight().partial_cmp(&h1.get_weight()).unwrap());
     }
 
     let vlrEquivClasses: UnionFindEquivClasses<VirtualRangeIx> =
@@ -647,7 +648,7 @@ pub(crate) fn do_coalescing_analysis<'a, F: Function>(
         n = 0;
         for hints_for_one_vlr in hints.iter() {
             let mut s = "".to_string();
-            for hint in hints_for_one_vlr {
+            for hint in hints_for_one_vlr.iter() {
                 s = s + &show_hint(hint, &univ) + &" ".to_string();
             }
             debug!("  hintsfor {:<4?} = {}", VirtualRangeIx::new(n), s);

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -16,10 +16,10 @@ use crate::bt_commitment_map::{CommitmentMap, RangeFragAndRangeId};
 use crate::bt_spillslot_allocator::SpillSlotAllocator;
 use crate::bt_vlr_priority_queue::VirtualRangePrioQ;
 use crate::data_structures::{
-    BlockIx, InstIx, InstPoint, Map, Point, RangeFrag, RangeFragIx, RangeId, RealRange,
-    RealRangeIx, RealReg, RealRegUniverse, Reg, RegClass, RegVecBounds, RegVecs, RegVecsAndBounds,
-    Set, SortedRangeFrags, SpillCost, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx,
-    VirtualReg, Writable,
+    BlockIx, InstIx, InstPoint, Point, RangeFrag, RangeFragIx, RangeId, RealRange, RealRangeIx,
+    RealReg, RealRegUniverse, Reg, RegClass, RegVecBounds, RegVecs, RegVecsAndBounds, Set,
+    SortedRangeFrags, SpillCost, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx, VirtualReg,
+    Writable,
 };
 use crate::inst_stream::{
     edit_inst_stream, ExtPoint, InstExtPoint, InstToInsert, InstToInsertAndExtPoint,
@@ -27,6 +27,7 @@ use crate::inst_stream::{
 use crate::sparse_set::SparseSetU;
 use crate::union_find::UnionFindEquivClasses;
 use crate::{AlgorithmWithDefaults, Function, RegAllocError, RegAllocResult, StackmapRequestInfo};
+use crate::{Alloc, BumpVec};
 
 #[derive(Clone)]
 pub struct BacktrackingOptions {
@@ -134,14 +135,14 @@ impl PerRealReg {
 // adding their spill costs to `running_cost`.  Return false if, for one of
 // the 4 reasons documented below, the traversal has been abandoned, and true
 // if the search completed successfully.
-fn search_commitment_tree<IsAllowedToEvict>(
+fn search_commitment_tree<'a, IsAllowedToEvict>(
     // The running state, threaded through the tree traversal.  These
     // accumulate ranges and costs as we traverse the tree.  These are mutable
     // because our caller (`find_evict_set`) will want to try and allocate
     // multiple `RangeFrag`s in this tree, not just a single one, and so it
     // needs a way to accumulate the total evict-cost and evict-set for all
     // the `RangeFrag`s it iterates over.
-    running_set: &mut SparseSetU<[VirtualRangeIx; 4]>,
+    running_set: &mut SparseSetU<'a, [VirtualRangeIx; 4]>,
     running_cost: &mut SpillCost,
     // The tree to search.
     tree: &AVLTree<RangeFragAndRangeId>,
@@ -269,19 +270,20 @@ impl PerRealReg {
     //   non-infinite-cost eviction candidates.  This is by design (so as to
     //   guarantee that we can always allocate spill/reload bridges).
     #[inline(never)]
-    fn find_evict_set<IsAllowedToEvict>(
+    fn find_evict_set<'a, IsAllowedToEvict>(
         &self,
         would_like_to_add: VirtualRangeIx,
         allowed_to_evict: &IsAllowedToEvict,
         vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
-    ) -> Option<(SparseSetU<[VirtualRangeIx; 4]>, SpillCost)>
+        alloc: &Alloc<'a>,
+    ) -> Option<(SparseSetU<'a, [VirtualRangeIx; 4]>, SpillCost)>
     where
         IsAllowedToEvict: Fn(VirtualRangeIx) -> bool,
     {
         // Firstly, if the commitment tree is for this reg is empty, we can
         // declare success immediately.
         if self.committed.tree.root == AVL_NULL {
-            let evict_set = SparseSetU::<[VirtualRangeIx; 4]>::empty();
+            let evict_set = SparseSetU::<[VirtualRangeIx; 4]>::empty(alloc);
             let evict_cost = SpillCost::zero();
             return Some((evict_set, evict_cost));
         }
@@ -298,7 +300,7 @@ impl PerRealReg {
 
         // The overall evict set and cost so far.  These are updated as we iterate
         // over the fragments that make up `would_like_to_add`.
-        let mut running_set = SparseSetU::<[VirtualRangeIx; 4]>::empty();
+        let mut running_set = SparseSetU::<[VirtualRangeIx; 4]>::empty(alloc);
         let mut running_cost = SpillCost::zero();
 
         // "wlta" = would like to add
@@ -397,16 +399,24 @@ fn print_RA_state(
 //
 // This may fail, meaning the request is in some way nonsensical; failure is propagated upwards.
 
-fn get_stackmap_artefacts_at(
+fn get_stackmap_artefacts_at<'a>(
     spill_slot_allocator: &mut SpillSlotAllocator,
     univ: &RealRegUniverse,
     reftype_class: RegClass,
-    reg_vecs_and_bounds: &RegVecsAndBounds,
-    per_real_reg: &Vec<PerRealReg>,
-    rlr_env: &TypedIxVec<RealRangeIx, RealRange>,
-    vlr_env: &TypedIxVec<VirtualRangeIx, VirtualRange>,
+    reg_vecs_and_bounds: &RegVecsAndBounds<'a>,
+    per_real_reg: &[PerRealReg],
+    rlr_env: &TypedIxVec<'a, RealRangeIx, RealRange>,
+    vlr_env: &TypedIxVec<'a, VirtualRangeIx, VirtualRange>,
     iix: InstIx,
-) -> Result<(Vec<InstToInsert>, Vec<InstToInsert>, Vec<SpillSlot>), RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<
+    (
+        BumpVec<'a, InstToInsert>,
+        BumpVec<'a, InstToInsert>,
+        BumpVec<'a, SpillSlot>,
+    ),
+    RegAllocError,
+> {
     // From a code generation perspective, what we need to compute is:
     //
     // * Sbefore: real regs that are live at `iix.u`, that are reftypes
@@ -512,8 +522,8 @@ fn get_stackmap_artefacts_at(
 
     let frag = RangeFrag::new(InstPoint::new_reload(iix), InstPoint::new_spill(iix));
 
-    let mut spill_insns = Vec::<InstToInsert>::new();
-    let mut where_reg_got_spilled_to = Map::<RealReg, SpillSlot>::default();
+    let mut spill_insns = alloc.vec(16);
+    let mut where_reg_got_spilled_to = alloc.map(16);
 
     for from_reg in s_before.iter() {
         let to_slot = spill_slot_allocator.alloc_reftyped_spillslot_for_frag(frag.clone());
@@ -532,7 +542,7 @@ fn get_stackmap_artefacts_at(
     // Create the reload insns, as defined by Safter.  Except, we might as well use the map we
     // just made, since its domain is the same as Safter.
 
-    let mut reload_insns = Vec::<InstToInsert>::new();
+    let mut reload_insns = alloc.vec(16);
 
     for (to_reg, from_slot) in where_reg_got_spilled_to.iter() {
         let reload = InstToInsert::Reload {
@@ -547,7 +557,7 @@ fn get_stackmap_artefacts_at(
     // slots that happen to hold reftyped values, as well as the "extras" we created here, to
     // hold values of reftyped regs that are live over this instruction.
 
-    let reftyped_spillslots = spill_slot_allocator.get_reftyped_spillslots_at_inst_point(pt);
+    let reftyped_spillslots = spill_slot_allocator.get_reftyped_spillslots_at_inst_point(pt, alloc);
 
     debug!("reftyped_spillslots = {:?}", reftyped_spillslots);
 
@@ -656,13 +666,14 @@ impl fmt::Debug for EditListItem {
 // have any undefined VirtualReg/RealReg uses.
 
 #[inline(never)]
-pub fn alloc_main<F: Function>(
+pub(crate) fn alloc_main<'a, F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
     stackmap_request: Option<&StackmapRequestInfo>,
     use_checker: bool,
     opts: &BacktrackingOptions,
-) -> Result<RegAllocResult<F>, RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<RegAllocResult<'a, F>, RegAllocError> {
     // -------- Initial arrangements for stackmaps --------
     let empty_vec_vregs = vec![];
     let empty_vec_iixs = vec![];
@@ -695,6 +706,7 @@ pub fn alloc_main<F: Function>(
         client_wants_stackmaps,
         reftype_class,
         reftyped_vregs,
+        alloc,
     )
     .map_err(|err| RegAllocError::Analysis(err))?;
 
@@ -714,6 +726,7 @@ pub fn alloc_main<F: Function>(
         &frag_env,
         &reg_to_ranges_maps,
         &move_info,
+        alloc,
     );
     let mut hints: TypedIxVec<VirtualRangeIx, SmallVec<[Hint; 8]>> = coalescing_info.0;
     let vlrEquivClasses: UnionFindEquivClasses<VirtualRangeIx> = coalescing_info.1;
@@ -779,7 +792,7 @@ pub fn alloc_main<F: Function>(
     // assigned spill slot for each VirtualRange, if any.
     // `spill_slot_allocator` decides on the assignments and writes them into
     // `vlr_slot_env`.
-    let mut vlr_slot_env = TypedIxVec::<VirtualRangeIx, Option<SpillSlot>>::new();
+    let mut vlr_slot_env = TypedIxVec::<VirtualRangeIx, Option<SpillSlot>>::new(alloc);
     vlr_slot_env.resize(num_vlrs_initial, None);
     let mut spill_slot_allocator = SpillSlotAllocator::new();
 
@@ -972,6 +985,7 @@ pub fn alloc_main<F: Function>(
                             != Some(true)
                     },
                     &vlr_env,
+                    alloc,
                 );
             if let Some((vlrixs_to_evict, total_evict_cost)) = mb_evict_info {
                 // Stay sane #1
@@ -1052,6 +1066,7 @@ pub fn alloc_main<F: Function>(
                     // can't-be-evicted VLRs in this call."
                     &|_vlrix_to_evict| true,
                     &vlr_env,
+                    alloc,
                 );
             //
             //match mb_evict_info {
@@ -1302,7 +1317,7 @@ pub fn alloc_main<F: Function>(
                 last: InstPoint::new(sri.iix, new_vlr_last_pt),
             };
             debug!("--     new RangeFrag    {:?}", &new_vlr_frag);
-            let new_vlr_sfrags = SortedRangeFrags::unit(new_vlr_frag);
+            let new_vlr_sfrags = SortedRangeFrags::unit(new_vlr_frag, alloc);
             let new_vlr = VirtualRange {
                 vreg: curr_vlr_vreg,
                 rreg: None,
@@ -1564,7 +1579,7 @@ pub fn alloc_main<F: Function>(
     // Reload and spill instructions are missing.  To generate them, go through
     // the "edit list", which contains info on both how to generate the
     // instructions, and where to insert them.
-    let mut spills_n_reloads = Vec::<InstToInsertAndExtPoint>::new();
+    let mut spills_n_reloads = alloc.vec(16);
     let mut num_spills = 0; // stats only
     let mut num_reloads = 0; // stats only
     for eli in &edit_list_other {
@@ -1664,7 +1679,7 @@ pub fn alloc_main<F: Function>(
     }
 
     // There is one of these for every entry in `safepoint_insns`.
-    let mut stackmaps = Vec::<Vec<SpillSlot>>::new();
+    let mut stackmaps = alloc.vec(4);
 
     if !safepoint_insns.is_empty() {
         info!("alloc_main:   create safepoints and stackmaps");
@@ -1695,10 +1710,11 @@ pub fn alloc_main<F: Function>(
                 &reg_universe,
                 reftype_class,
                 &reg_vecs_and_bounds,
-                &per_real_reg,
+                &per_real_reg[..],
                 &rlr_env,
                 &vlr_env,
                 *safepoint_iix,
+                alloc,
             )?;
             stackmaps.push(reftyped_spillslots);
             for spill_before in spills_before {
@@ -1720,13 +1736,14 @@ pub fn alloc_main<F: Function>(
 
     let final_insns_and_targetmap_and_new_safepoints__or_err = edit_inst_stream(
         func,
-        spills_n_reloads,
-        &iixs_to_nop_out,
-        frag_map,
+        &spills_n_reloads[..],
+        &iixs_to_nop_out[..],
+        &frag_map[..],
         &reg_universe,
         use_checker,
         stackmap_request,
         &stackmaps[..],
+        alloc,
     );
 
     // ======== END Create final instruction stream ========
@@ -1784,7 +1801,7 @@ pub fn alloc_main<F: Function>(
     // That's inefficient, but we don't care .. this should only be a temporary
     // fix.
 
-    let mut clobbered_registers: Set<RealReg> = Set::empty();
+    let mut clobbered_registers = alloc.set(16);
 
     // We'll dump all the reg uses in here.  We don't care about the bounds, so just
     // pass a dummy one in the loop.
@@ -1802,18 +1819,20 @@ pub fn alloc_main<F: Function>(
 
     // And now remove from the set, all those not available to the allocator.
     // But not removing the reserved regs, since we might have modified those.
-    clobbered_registers.filter_map(|&reg| {
-        if reg.get_index() >= reg_universe.allocable {
-            None
-        } else {
-            Some(reg)
+    let clobbered_registers = {
+        let mut n = alloc.set(clobbered_registers.len());
+        for reg in clobbered_registers {
+            if reg.get_index() < reg_universe.allocable {
+                n.insert(reg);
+            }
         }
-    });
+        n
+    };
 
     assert!(est_freqs.len() as usize == func.blocks().len());
     let mut block_annotations = None;
     if opts.request_block_annotations {
-        let mut anns = TypedIxVec::<BlockIx, Vec<String>>::new();
+        let mut anns = vec![];
         for (estFreq, i) in est_freqs.iter().zip(0..) {
             let bix = BlockIx::new(i);
             let ef_str = format!("RA: bix {:?}, estFreq {}", bix, estFreq);

--- a/lib/src/bt_spillslot_allocator.rs
+++ b/lib/src/bt_spillslot_allocator.rs
@@ -10,6 +10,7 @@ use crate::data_structures::{
 };
 use crate::union_find::UnionFindEquivClasses;
 use crate::Function;
+use crate::{Alloc, BumpVec};
 
 //=============================================================================
 // A spill slot allocator.  This could be implemented more simply than it is.
@@ -505,8 +506,12 @@ impl SpillSlotAllocator {
 
     /// Stackmap support: Examine all the spill slots at `pt` and return those that are reftyped.
     /// This is fundamentally what creates a stack map.
-    pub(crate) fn get_reftyped_spillslots_at_inst_point(&self, pt: InstPoint) -> Vec<SpillSlot> {
-        let mut res = Vec::<SpillSlot>::new();
+    pub(crate) fn get_reftyped_spillslots_at_inst_point<'a>(
+        &self,
+        pt: InstPoint,
+        alloc: &Alloc<'a>,
+    ) -> BumpVec<'a, SpillSlot> {
+        let mut res = alloc.vec(16);
         for (i, slot) in self.slots.iter().enumerate() {
             if slot.get_refness_at_inst_point(pt) == Some(true) {
                 res.push(SpillSlot::new(i as u32));

--- a/lib/src/bump.rs
+++ b/lib/src/bump.rs
@@ -1,0 +1,343 @@
+//! Allocation with bumpalo
+
+pub use bumpalo::Bump;
+use hashbrown::raw::{AllocError, Allocator};
+use std::alloc::Layout;
+use std::hash::BuildHasherDefault;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeTo};
+
+/// An arena allocator wrapped around a `bumpalo::Bump`.
+#[derive(Clone)]
+pub struct Alloc<'a>(pub &'a Bump);
+
+// Export arena-allocated container types.
+pub use bumpalo::collections::Vec as BumpVec;
+type BuildHasher = BuildHasherDefault<rustc_hash::FxHasher>;
+pub type BumpMap<'bump, K, V> = hashbrown::HashMap<K, V, BuildHasher, Alloc<'bump>>;
+pub type BumpSet<'bump, T> = hashbrown::HashSet<T, BuildHasher, Alloc<'bump>>;
+use core::ptr::NonNull;
+
+// Implement the allocator for hashbrown.
+unsafe impl<'a> Allocator for Alloc<'a> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Ok(self.0.alloc_layout(layout))
+    }
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}
+
+impl<'a> Alloc<'a> {
+    /// Allocate a new BumpVec.
+    pub fn vec<T>(&self, capacity: usize) -> BumpVec<'a, T> {
+        BumpVec::with_capacity_in(capacity, self.0)
+    }
+    /// Allocate a new BumpMap.
+    pub fn map<K, V>(&self, capacity: usize) -> BumpMap<'a, K, V> {
+        BumpMap::with_capacity_and_hasher_in(capacity, BuildHasher::default(), self.clone())
+    }
+    /// Allocate a new BumpSet.
+    pub fn set<T: Eq + std::hash::Hash>(&self, capacity: usize) -> BumpSet<'a, T> {
+        BumpSet::with_capacity_and_hasher_in(capacity, BuildHasher::default(), self.clone())
+    }
+    /// Collect into a BumpVec.
+    pub fn collect<T>(&self, iter: impl Iterator<Item = T>) -> BumpVec<'a, T> {
+        let mut v = self.vec(0);
+        v.extend(iter);
+        v
+    }
+    /// Clone a BumpSet.
+    pub fn clone_set<'b, T: Clone + Eq + std::hash::Hash>(
+        &self,
+        set: &BumpSet<'b, T>,
+    ) -> BumpSet<'a, T> {
+        let mut ret = self.set(set.len());
+        for item in set.iter() {
+            ret.insert(item.clone());
+        }
+        ret
+    }
+    /// Clone a BumpMap.
+    pub fn clone_map<'b, K: Clone + Eq + std::hash::Hash, V: Clone>(
+        &self,
+        map: &BumpMap<'b, K, V>,
+    ) -> BumpMap<'a, K, V> {
+        let mut ret = self.map(map.len());
+        for (k, v) in map.iter() {
+            ret.insert(k.clone(), v.clone());
+        }
+        ret
+    }
+}
+
+/// SmallVec wrapper that performs bump-allocation in heap mode.
+pub struct BumpSmallVec<'a, A: smallvec::Array> {
+    capacity: usize,
+    len: usize,
+    data: BumpSmallVecData<A>,
+    _lifetime: PhantomData<&'a ()>,
+}
+
+union BumpSmallVecData<A: smallvec::Array> {
+    data: *mut A::Item,
+    array: std::mem::ManuallyDrop<A>,
+}
+
+impl<'a, A: smallvec::Array> BumpSmallVec<'a, A> {
+    pub fn new() -> Self {
+        assert!(A::size() > 0);
+        BumpSmallVec {
+            capacity: A::size(),
+            len: 0,
+            data: BumpSmallVecData {
+                data: 0 as *mut A::Item,
+            },
+            _lifetime: PhantomData,
+        }
+    }
+
+    pub fn clone<'b>(&self, alloc: &Alloc<'b>) -> BumpSmallVec<'b, A>
+    where
+        A::Item: Clone,
+    {
+        let mut ret = BumpSmallVec::new();
+        ret.reserve(self.len(), alloc);
+        ret.extend(self.iter().cloned(), alloc);
+        ret
+    }
+
+    pub fn from(iter: impl IntoIterator<Item = A::Item>, alloc: &Alloc<'a>) -> Self {
+        let iter = iter.into_iter();
+        let mut ret = BumpSmallVec::new();
+        for item in iter {
+            ret.push(item, alloc);
+        }
+        ret
+    }
+
+    pub fn reserve<'b>(&'b mut self, capacity: usize, alloc: &Alloc<'a>)
+    where
+        'a: 'b,
+    {
+        if capacity > self.capacity {
+            if capacity > A::size() && self.capacity <= A::size() {
+                self.grow_into_mem(capacity, alloc);
+            } else if capacity > A::size() {
+                self.expand_mem(capacity, alloc);
+            } else {
+                self.capacity = capacity;
+            }
+        }
+    }
+
+    fn alloc_mem(capacity: usize, alloc: &Alloc<'a>) -> *mut A::Item {
+        let size = capacity * std::mem::size_of::<A::Item>();
+        let size = (size + 7) & !7;
+        let mem = alloc
+            .allocate(Layout::from_size_align(size, 8).unwrap())
+            .unwrap_or_else(|_| panic!("Allocation failure"));
+        mem.as_ptr() as *mut A::Item
+    }
+
+    fn array_ptr(&self) -> *const A::Item {
+        assert!(self.capacity <= A::size());
+        let arr: &A = unsafe { self.data.array.deref() };
+        unsafe { std::mem::transmute(arr) }
+    }
+
+    fn array_ptr_mut(&mut self) -> *mut A::Item {
+        assert!(self.capacity <= A::size());
+        let arr: &mut A = unsafe { self.data.array.deref_mut() };
+        unsafe { std::mem::transmute(arr) }
+    }
+
+    fn grow_into_mem(&mut self, capacity: usize, alloc: &Alloc<'a>) {
+        let mem = Self::alloc_mem(capacity, alloc);
+        unsafe {
+            std::ptr::copy_nonoverlapping(self.array_ptr(), mem, self.len);
+            self.data.data = mem;
+        }
+        self.capacity = capacity;
+    }
+
+    fn expand_mem(&mut self, capacity: usize, alloc: &Alloc<'a>) {
+        let mem = Self::alloc_mem(capacity, alloc);
+        unsafe {
+            let old_data = self.data.data;
+            std::ptr::copy_nonoverlapping(old_data, mem, self.len);
+            self.data.data = mem;
+        }
+        self.capacity = capacity;
+    }
+
+    fn items(&self) -> &[A::Item] {
+        let data: *const A::Item = if self.capacity > A::size() {
+            unsafe { self.data.data }
+        } else {
+            self.array_ptr()
+        };
+        unsafe { std::slice::from_raw_parts(data, self.len) }
+    }
+
+    fn items_mut(&mut self) -> &mut [A::Item] {
+        let data: *mut A::Item = if self.capacity > A::size() {
+            unsafe { self.data.data }
+        } else {
+            self.array_ptr_mut()
+        };
+        unsafe { std::slice::from_raw_parts_mut(data, self.len) }
+    }
+
+    pub fn push<'b>(&'b mut self, item: A::Item, alloc: &Alloc<'a>)
+    where
+        'a: 'b,
+    {
+        let idx = self.len;
+        self.len += 1;
+        if self.len > self.capacity {
+            self.reserve(self.capacity * 2, alloc);
+        }
+        let item_ptr = &mut self.items_mut()[idx] as *mut A::Item;
+        unsafe {
+            std::ptr::write(item_ptr, item);
+        }
+    }
+
+    pub fn extend<'b>(&'b mut self, items: impl Iterator<Item = A::Item>, alloc: &Alloc<'a>)
+    where
+        'a: 'b,
+    {
+        for item in items {
+            self.push(item, alloc);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn pop(&mut self) -> Option<A::Item> {
+        if self.len == 0 {
+            None
+        } else {
+            let item_ptr = &self.items()[self.len - 1] as *const A::Item;
+            let ret = unsafe { std::ptr::read(item_ptr) };
+            self.len -= 1;
+            Some(ret)
+        }
+    }
+
+    pub fn iter<'b>(&'b self) -> std::slice::Iter<'b, A::Item> {
+        self.items().iter()
+    }
+
+    pub fn iter_mut<'b>(&'b mut self) -> std::slice::IterMut<'b, A::Item> {
+        self.items_mut().iter_mut()
+    }
+}
+
+impl<'a, A: smallvec::Array> Index<usize> for BumpSmallVec<'a, A> {
+    type Output = A::Item;
+    fn index(&self, idx: usize) -> &A::Item {
+        &self.items()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> IndexMut<usize> for BumpSmallVec<'a, A> {
+    fn index_mut(&mut self, idx: usize) -> &mut A::Item {
+        &mut self.items_mut()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> Index<Range<usize>> for BumpSmallVec<'a, A> {
+    type Output = [A::Item];
+    fn index(&self, idx: Range<usize>) -> &[A::Item] {
+        &self.items()[idx.start..idx.end]
+    }
+}
+
+impl<'a, A: smallvec::Array> IndexMut<Range<usize>> for BumpSmallVec<'a, A> {
+    fn index_mut(&mut self, idx: Range<usize>) -> &mut [A::Item] {
+        &mut self.items_mut()[idx.start..idx.end]
+    }
+}
+
+impl<'a, A: smallvec::Array> Index<RangeTo<usize>> for BumpSmallVec<'a, A> {
+    type Output = [A::Item];
+    fn index(&self, idx: RangeTo<usize>) -> &[A::Item] {
+        &self.items()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> IndexMut<RangeTo<usize>> for BumpSmallVec<'a, A> {
+    fn index_mut(&mut self, idx: RangeTo<usize>) -> &mut [A::Item] {
+        &mut self.items_mut()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> Index<RangeFrom<usize>> for BumpSmallVec<'a, A> {
+    type Output = [A::Item];
+    fn index(&self, idx: RangeFrom<usize>) -> &[A::Item] {
+        &self.items()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> IndexMut<RangeFrom<usize>> for BumpSmallVec<'a, A> {
+    fn index_mut(&mut self, idx: RangeFrom<usize>) -> &mut [A::Item] {
+        &mut self.items_mut()[idx]
+    }
+}
+
+impl<'a, A: smallvec::Array> Index<RangeFull> for BumpSmallVec<'a, A> {
+    type Output = [A::Item];
+    fn index(&self, _: RangeFull) -> &[A::Item] {
+        &self.items()[..]
+    }
+}
+
+impl<'a, A: smallvec::Array> IndexMut<RangeFull> for BumpSmallVec<'a, A> {
+    fn index_mut(&mut self, _: RangeFull) -> &mut [A::Item] {
+        &mut self.items_mut()[..]
+    }
+}
+
+impl<'a, A: smallvec::Array> std::fmt::Debug for BumpSmallVec<'a, A>
+where
+    A::Item: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.items().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bump_smallvec() {
+        let bump = Bump::new();
+        let alloc = Alloc(&bump);
+
+        let mut v: BumpSmallVec<[u32; 2]> = BumpSmallVec::new();
+        v.reserve(2, &alloc);
+        v.push(1, &alloc);
+        v.push(2, &alloc);
+        assert_eq!(&v[..], &[1, 2]);
+        v.push(3, &alloc);
+        v.push(4, &alloc);
+        assert_eq!(&v[..], &[1, 2, 3, 4]);
+        let vec = v.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(&vec[..], &v[..]);
+        *(&mut v[0]) = 5;
+        assert_eq!(&v[..], &[5, 2, 3, 4]);
+        assert_eq!(&v[..2], &[5, 2]);
+        assert_eq!(&v[2..], &[3, 4]);
+        assert_eq!(&v[1..3], &[2, 3]);
+        v.extend(vec![0, 0].into_iter(), &alloc);
+        assert_eq!(&v[..], &[5, 2, 3, 4, 0, 0]);
+        assert_eq!(&format!("{:?}", v), "[5, 2, 3, 4, 0, 0]");
+
+        let v2: BumpSmallVec<[u32; 2]> = BumpSmallVec::from(vec![1, 2, 3, 4], &alloc);
+        assert_eq!(&v2[..], &[1, 2, 3, 4]);
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,74 @@ use log::{info, log_enabled, Level};
 use std::default;
 use std::{borrow::Cow, fmt};
 
+// Allocation with bumpalo
+pub use bumpalo::Bump;
+use hashbrown::raw::{AllocError, Allocator};
+use std::alloc::Layout;
+
+/// An arena allocator wrapped around a `bumpalo::Bump`.
+#[derive(Clone)]
+pub struct Alloc<'a>(pub &'a Bump);
+
+// Export arena-allocated container types.
+pub use bumpalo::collections::Vec as BumpVec;
+pub type BumpMap<'bump, K, V> =
+    hashbrown::HashMap<K, V, hashbrown::hash_map::DefaultHashBuilder, Alloc<'bump>>;
+pub type BumpSet<'bump, T> =
+    hashbrown::HashSet<T, hashbrown::hash_map::DefaultHashBuilder, Alloc<'bump>>;
+use core::ptr::NonNull;
+
+// Implement the allocator for hashbrown.
+unsafe impl<'a> Allocator for Alloc<'a> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Ok(self.0.alloc_layout(layout))
+    }
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}
+
+impl<'a> Alloc<'a> {
+    /// Allocate a new BumpVec.
+    pub fn vec<T>(&self, capacity: usize) -> BumpVec<'a, T> {
+        BumpVec::with_capacity_in(capacity, self.0)
+    }
+    /// Allocate a new BumpMap.
+    pub fn map<K, V>(&self, capacity: usize) -> BumpMap<'a, K, V> {
+        BumpMap::with_capacity_in(capacity, self.clone())
+    }
+    /// Allocate a new BumpSet.
+    pub fn set<T: Eq + std::hash::Hash>(&self, capacity: usize) -> BumpSet<'a, T> {
+        BumpSet::with_capacity_in(capacity, self.clone())
+    }
+    /// Collect into a BumpVec.
+    pub fn collect<T>(&self, iter: impl Iterator<Item = T>) -> BumpVec<'a, T> {
+        let mut v = self.vec(0);
+        v.extend(iter);
+        v
+    }
+    /// Clone a BumpSet.
+    pub fn clone_set<'b, T: Clone + Eq + std::hash::Hash>(
+        &self,
+        set: &BumpSet<'b, T>,
+    ) -> BumpSet<'a, T> {
+        let mut ret = self.set(set.len());
+        for item in set.iter() {
+            ret.insert(item.clone());
+        }
+        ret
+    }
+    /// Clone a BumpMap.
+    pub fn clone_map<'b, K: Clone + Eq + std::hash::Hash, V: Clone>(
+        &self,
+        map: &BumpMap<'b, K, V>,
+    ) -> BumpMap<'a, K, V> {
+        let mut ret = self.map(map.len());
+        for (k, v) in map.iter() {
+            ret.insert(k.clone(), v.clone());
+        }
+        ret
+    }
+}
+
 // Stuff that is defined by the library
 
 // Pretty-printing utilities.
@@ -361,16 +429,19 @@ pub trait Function {
 }
 
 /// The result of register allocation.  Note that allocation can fail!
-pub struct RegAllocResult<F: Function> {
+pub struct RegAllocResult<'a, F: Function> {
     /// A new sequence of instructions with all register slots filled with real
     /// registers, and spills/fills/moves possibly inserted (and unneeded moves
     /// elided).
+    ///
+    /// Note that this is a `Vec`, not a `BumpVec`, because `F::Inst` may have
+    /// a nontrivial `Drop` and `bumpalo::Bump` does not invoke `Drop` impls.
     pub insns: Vec<F::Inst>,
 
     /// Basic-block start indices for the new instruction list, indexed by the
     /// original basic block indices. May be used by the client to, e.g., remap
     /// branch targets appropriately.
-    pub target_map: TypedIxVec<BlockIx, InstIx>,
+    pub target_map: TypedIxVec<'a, BlockIx, InstIx>,
 
     /// Full mapping from new instruction indices to original instruction
     /// indices. May be needed by the client to, for example, update metadata
@@ -380,14 +451,14 @@ pub struct RegAllocResult<F: Function> {
     /// Each entry is an `InstIx`, but may be `InstIx::invalid_value()` if the
     /// new instruction at this new index was inserted by the allocator
     /// (i.e., if it is a load, spill or move instruction).
-    pub orig_insn_map: TypedIxVec</* new */ InstIx, /* orig */ InstIx>,
+    pub orig_insn_map: TypedIxVec<'a, /* new */ InstIx, /* orig */ InstIx>,
 
     /// Which real registers were overwritten? This will contain all real regs
     /// that appear as defs or modifies in register slots of the output
     /// instruction list.  This will only list registers that are available to
     /// the allocator.  If one of the instructions clobbers a register which
     /// isn't available to the allocator, it won't be mentioned here.
-    pub clobbered_registers: Set<RealReg>,
+    pub clobbered_registers: BumpSet<'a, RealReg>,
 
     /// How many spill slots were used?
     pub num_spill_slots: u32,
@@ -395,15 +466,15 @@ pub struct RegAllocResult<F: Function> {
     /// Block annotation strings, for debugging.  Requires requesting in the
     /// call to `allocate_registers`.  Creating of these annotations is
     /// potentially expensive, so don't request them if you don't need them.
-    pub block_annotations: Option<TypedIxVec<BlockIx, Vec<String>>>,
+    pub block_annotations: Option<Vec</* BlockIx, */ Vec<String>>>,
 
     /// If stackmap support was requested: one stackmap for each of the safepoint instructions
     /// declared.  Otherwise empty.
-    pub stackmaps: Vec<Vec<SpillSlot>>,
+    pub stackmaps: BumpVec<'a, BumpVec<'a, SpillSlot>>,
 
     /// If stackmap support was requested: one InstIx for each safepoint instruction declared,
     /// indicating the corresponding location in the final instruction stream.  Otherwise empty.
-    pub new_safepoint_insns: Vec<InstIx>,
+    pub new_safepoint_insns: BumpVec<'a, InstIx>,
 }
 
 /// A choice of register allocation algorithm to run.
@@ -516,12 +587,13 @@ pub struct StackmapRequestInfo {
 /// common to all the backends. The choice of algorithm is done by passing a given [Algorithm]
 /// instance, with options tailored for each algorithm.
 #[inline(never)]
-pub fn allocate_registers_with_opts<F: Function>(
+pub fn allocate_registers_with_opts<'a, F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
     stackmap_info: Option<&StackmapRequestInfo>,
     opts: Options,
-) -> Result<RegAllocResult<F>, RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<RegAllocResult<'a, F>, RegAllocError> {
     info!("");
     info!("================ regalloc.rs: BEGIN function ================");
 
@@ -591,12 +663,22 @@ pub fn allocate_registers_with_opts<F: Function>(
 
     let run_checker = opts.run_checker;
     let res = match &opts.algorithm {
-        Algorithm::Backtracking(opts) => {
-            bt_main::alloc_main(func, rreg_universe, stackmap_info, run_checker, opts)
-        }
-        Algorithm::LinearScan(opts) => {
-            linear_scan::run(func, rreg_universe, stackmap_info, run_checker, opts)
-        }
+        Algorithm::Backtracking(opts) => bt_main::alloc_main(
+            func,
+            rreg_universe,
+            stackmap_info,
+            run_checker,
+            opts,
+            &alloc,
+        ),
+        Algorithm::LinearScan(opts) => linear_scan::run(
+            func,
+            rreg_universe,
+            stackmap_info,
+            run_checker,
+            opts,
+            &alloc,
+        ),
     };
 
     info!("================ regalloc.rs: END function ================");
@@ -617,12 +699,13 @@ pub fn allocate_registers_with_opts<F: Function>(
 /// This is a convenient function that uses standard options for the allocator, according to the
 /// selected algorithm.
 #[inline(never)]
-pub fn allocate_registers<F: Function>(
+pub fn allocate_registers<'a, F: Function>(
     func: &mut F,
     rreg_universe: &RealRegUniverse,
     stackmap_info: Option<&StackmapRequestInfo>,
     algorithm: AlgorithmWithDefaults,
-) -> Result<RegAllocResult<F>, RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<RegAllocResult<'a, F>, RegAllocError> {
     let algorithm = match algorithm {
         AlgorithmWithDefaults::Backtracking => Algorithm::Backtracking(Default::default()),
         AlgorithmWithDefaults::LinearScan => Algorithm::LinearScan(Default::default()),
@@ -631,7 +714,7 @@ pub fn allocate_registers<F: Function>(
         algorithm,
         ..Default::default()
     };
-    allocate_registers_with_opts(func, rreg_universe, stackmap_info, opts)
+    allocate_registers_with_opts(func, rreg_universe, stackmap_info, opts, alloc)
 }
 
 // Facilities to snapshot regalloc inputs and reproduce them in regalloc.rs.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -22,6 +22,7 @@ mod bt_commitment_map;
 mod bt_main;
 mod bt_spillslot_allocator;
 mod bt_vlr_priority_queue;
+mod bump;
 mod checker;
 mod data_structures;
 mod inst_stream;
@@ -31,7 +32,6 @@ mod reg_maps;
 mod snapshot;
 mod sparse_set;
 mod union_find;
-mod bump;
 
 use log::{info, log_enabled, Level};
 use std::default;

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -12,7 +12,7 @@ use std::{cmp::Ordering, default};
 
 use crate::{
     checker::CheckerContext, reg_maps::MentionRegUsageMapper, Function, RealRegUniverse,
-    RegAllocError, RegAllocResult, RegClass, Set, SpillSlot, VirtualReg, NUM_REG_CLASSES,
+    RegAllocError, RegAllocResult, RegClass, SpillSlot, VirtualReg, NUM_REG_CLASSES,
 };
 use crate::{
     checker::CheckerStackmapInfo,
@@ -22,9 +22,9 @@ use crate::{
     data_structures::{BlockIx, InstIx, InstPoint, Point, RealReg, RegVecsAndBounds},
     CheckerErrors, StackmapRequestInfo,
 };
+use crate::{Alloc, BumpSet, BumpVec};
 
 use analysis::{AnalysisInfo, RangeFrag};
-use smallvec::SmallVec;
 
 use self::analysis::{BlockBoundary, BlockPos};
 
@@ -133,7 +133,7 @@ impl fmt::Debug for LinearScanOptions {
 }
 
 // Local shorthands.
-type RegUses = RegVecsAndBounds;
+type RegUses<'a> = RegVecsAndBounds<'a>;
 
 /// A unique identifier for an interval.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -146,12 +146,12 @@ impl fmt::Debug for IntId {
 }
 
 #[derive(Clone)]
-struct FixedInterval {
+struct FixedInterval<'a> {
     reg: RealReg,
-    frags: Vec<RangeFrag>,
+    frags: BumpVec<'a, RangeFrag<'a>>,
 }
 
-impl fmt::Display for FixedInterval {
+impl<'a> fmt::Display for FixedInterval<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "fixed {:?} [", self.reg)?;
         for (i, frag) in self.frags.iter().enumerate() {
@@ -167,7 +167,7 @@ impl fmt::Display for FixedInterval {
     }
 }
 
-impl FixedInterval {
+impl<'a> FixedInterval<'a> {
     /// Find the fragment that contains the given instruction point.
     /// May crash if the point doesn't belong to any fragment.
     pub(crate) fn find_frag(&self, pt: InstPoint) -> usize {
@@ -185,10 +185,10 @@ impl FixedInterval {
     }
 }
 
-type Safepoints = SmallVec<[(InstIx, usize); 8]>;
+type Safepoints<'a> = BumpVec<'a, (InstIx, usize)>;
 
 #[derive(Clone)]
-pub(crate) struct VirtualInterval {
+pub(crate) struct VirtualInterval<'a> {
     id: IntId,
     vreg: VirtualReg,
 
@@ -204,14 +204,14 @@ pub(crate) struct VirtualInterval {
     /// Location assigned to this live interval.
     location: Location,
 
-    mentions: MentionMap,
-    block_boundaries: Vec<BlockBoundary>,
-    safepoints: Safepoints,
+    mentions: MentionMap<'a>,
+    block_boundaries: BumpVec<'a, BlockBoundary>,
+    safepoints: Safepoints<'a>,
     start: InstPoint,
     end: InstPoint,
 }
 
-impl fmt::Display for VirtualInterval {
+impl<'a> fmt::Display for VirtualInterval<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "virtual {:?}", self.id)?;
         if self.ref_typed {
@@ -257,16 +257,16 @@ impl fmt::Display for VirtualInterval {
     }
 }
 
-impl VirtualInterval {
+impl<'a> VirtualInterval<'a> {
     fn new(
         id: IntId,
         vreg: VirtualReg,
         start: InstPoint,
         end: InstPoint,
-        mentions: MentionMap,
-        block_boundaries: Vec<BlockBoundary>,
+        mentions: MentionMap<'a>,
+        block_boundaries: BumpVec<'a, BlockBoundary>,
         ref_typed: bool,
-        safepoints: Safepoints,
+        safepoints: Safepoints<'a>,
     ) -> Self {
         Self {
             id,
@@ -283,22 +283,22 @@ impl VirtualInterval {
             ref_typed,
         }
     }
-    fn safepoints(&self) -> &Safepoints {
+    fn safepoints(&self) -> &Safepoints<'a> {
         &self.safepoints
     }
-    fn safepoints_mut(&mut self) -> &mut Safepoints {
+    fn safepoints_mut(&mut self) -> &mut Safepoints<'a> {
         &mut self.safepoints
     }
     fn mentions(&self) -> &MentionMap {
         &self.mentions
     }
-    fn mentions_mut(&mut self) -> &mut MentionMap {
+    fn mentions_mut(&mut self) -> &mut MentionMap<'a> {
         &mut self.mentions
     }
     fn block_boundaries(&self) -> &[BlockBoundary] {
         &self.block_boundaries
     }
-    fn block_boundaries_mut(&mut self) -> &mut Vec<BlockBoundary> {
+    fn block_boundaries_mut(&mut self) -> &mut BumpVec<'a, BlockBoundary> {
         &mut self.block_boundaries
     }
     fn covers(&self, pos: InstPoint) -> bool {
@@ -369,7 +369,7 @@ impl Mention {
     }
 }
 
-pub type MentionMap = SmallVec<[(InstIx, Mention); 2]>;
+pub type MentionMap<'a> = BumpVec<'a, (InstIx, Mention)>;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Location {
@@ -410,16 +410,16 @@ impl fmt::Display for Location {
 }
 
 /// A group of live intervals.
-pub struct Intervals {
-    virtuals: Vec<VirtualInterval>,
-    fixeds: Vec<FixedInterval>,
+pub struct Intervals<'a> {
+    virtuals: BumpVec<'a, VirtualInterval<'a>>,
+    fixeds: BumpVec<'a, FixedInterval<'a>>,
 }
 
-impl Intervals {
-    fn get(&self, int_id: IntId) -> &VirtualInterval {
+impl<'a> Intervals<'a> {
+    fn get(&self, int_id: IntId) -> &VirtualInterval<'a> {
         &self.virtuals[int_id.0]
     }
-    fn get_mut(&mut self, int_id: IntId) -> &mut VirtualInterval {
+    fn get_mut(&mut self, int_id: IntId) -> &mut VirtualInterval<'a> {
         &mut self.virtuals[int_id.0]
     }
     fn num_virtual_intervals(&self) -> usize {
@@ -437,7 +437,7 @@ impl Intervals {
         debug_assert!(int.location.spill().is_none());
         int.location = Location::Stack(slot);
     }
-    fn push_interval(&mut self, int: VirtualInterval) {
+    fn push_interval(&mut self, int: VirtualInterval<'a>) {
         debug_assert!(int.id.0 == self.virtuals.len());
         self.virtuals.push(int);
     }
@@ -591,10 +591,11 @@ fn last_use(interval: &VirtualInterval, pos: InstPoint, _reg_uses: &RegUses) -> 
 
 /// Checks that each register class has its own scratch register in addition to one available
 /// register, and creates a mapping of register class -> scratch register.
-fn compute_scratches(
+fn compute_scratches<'a>(
     reg_universe: &RealRegUniverse,
-) -> Result<Vec<Option<RealReg>>, RegAllocError> {
-    let mut scratches_by_rc = vec![None; NUM_REG_CLASSES];
+    alloc: &Alloc<'a>,
+) -> Result<BumpVec<'a, Option<RealReg>>, RegAllocError> {
+    let mut scratches_by_rc = alloc.collect(std::iter::repeat(None).take(NUM_REG_CLASSES));
     for i in 0..NUM_REG_CLASSES {
         if let Some(info) = &reg_universe.allocable_by_class[i] {
             if info.first == info.last {
@@ -622,13 +623,14 @@ fn compute_scratches(
 /// Allocation can fail if there are insufficient registers to even generate spill/reload code, or
 /// if the function appears to have any undefined VirtualReg/RealReg uses.
 #[inline(never)]
-pub(crate) fn run<F: Function>(
+pub(crate) fn run<'a, F: Function>(
     func: &mut F,
     reg_universe: &RealRegUniverse,
     stackmap_request: Option<&StackmapRequestInfo>,
     use_checker: bool,
     opts: &LinearScanOptions,
-) -> Result<RegAllocResult<F>, RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<RegAllocResult<'a, F>, RegAllocError> {
     let AnalysisInfo {
         reg_vecs_and_bounds: reg_uses,
         intervals,
@@ -636,10 +638,10 @@ pub(crate) fn run<F: Function>(
         liveouts,
         cfg,
         ..
-    } = analysis::run(func, reg_universe, stackmap_request)
+    } = analysis::run(func, reg_universe, stackmap_request, alloc)
         .map_err(|err| RegAllocError::Analysis(err))?;
 
-    let scratches_by_rc = compute_scratches(reg_universe)?;
+    let scratches_by_rc = compute_scratches(reg_universe, alloc)?;
 
     let stats = if opts.stats {
         let mut stats = Statistics::default();
@@ -680,6 +682,7 @@ pub(crate) fn run<F: Function>(
         &scratches_by_rc,
         intervals,
         stats,
+        alloc,
     )?;
 
     let virtuals = &intervals.virtuals;
@@ -688,37 +691,40 @@ pub(crate) fn run<F: Function>(
         func,
         &cfg,
         &reg_uses,
-        virtuals,
+        &virtuals[..],
         &liveins,
         &liveouts,
         &mut num_spill_slots,
         &scratches_by_rc,
+        alloc,
     );
 
     apply_registers(
         func,
-        virtuals,
-        memory_moves,
+        &virtuals[..],
+        &memory_moves[..],
         reg_universe,
         num_spill_slots,
         use_checker,
         stackmap_request,
+        alloc,
     )
 }
 
 #[inline(never)]
-fn set_registers<F: Function>(
+fn set_registers<'a, F: Function>(
     func: &mut F,
-    virtual_intervals: &Vec<VirtualInterval>,
+    virtual_intervals: &[VirtualInterval],
     reg_universe: &RealRegUniverse,
     use_checker: bool,
-    memory_moves: &Vec<InstToInsertAndExtPoint>,
+    memory_moves: &[InstToInsertAndExtPoint],
     stackmap_request: Option<&StackmapRequestInfo>,
-    stackmaps: &[Vec<SpillSlot>],
-) -> Result<Set<RealReg>, CheckerErrors> {
+    stackmaps: &[BumpVec<'a, SpillSlot>],
+    alloc: &Alloc<'a>,
+) -> Result<BumpSet<'a, RealReg>, CheckerErrors> {
     info!("set_registers");
 
-    let mut clobbered_registers = Set::empty();
+    let mut clobbered_registers = alloc.set(16);
 
     // Collect all the regs per instruction and mention set.
     let capacity = virtual_intervals
@@ -731,7 +737,7 @@ fn set_registers<F: Function>(
         return Ok(clobbered_registers);
     }
 
-    let mut mention_map = Vec::with_capacity(capacity);
+    let mut mention_map = alloc.vec(capacity);
 
     for int in virtual_intervals {
         let rreg = match int.location.reg() {
@@ -753,7 +759,7 @@ fn set_registers<F: Function>(
 
     // Set up checker state, if indicated by our configuration.
     let mut checker: Option<CheckerContext> = None;
-    let mut insn_blocks: Vec<BlockIx> = vec![];
+    let mut insn_blocks = alloc.vec(0);
     if use_checker {
         let stackmap_info =
             stackmap_request.map(|request| CheckerStackmapInfo { request, stackmaps });
@@ -762,6 +768,7 @@ fn set_registers<F: Function>(
             reg_universe,
             memory_moves,
             stackmap_info,
+            alloc,
         ));
         insn_blocks.resize(func.insns().len(), BlockIx::new(0));
         for block_ix in func.blocks() {
@@ -852,12 +859,16 @@ fn set_registers<F: Function>(
     Ok(clobbered_registers)
 }
 
-fn compute_stackmaps(
+fn compute_stackmaps<'a>(
     intervals: &[VirtualInterval],
     stackmap_request: Option<&StackmapRequestInfo>,
-) -> Vec<Vec<SpillSlot>> {
+    alloc: &Alloc<'a>,
+) -> BumpVec<'a, BumpVec<'a, SpillSlot>> {
     if let Some(request) = stackmap_request {
-        let mut stackmaps = vec![Vec::new(); request.safepoint_insns.len()];
+        let mut stackmaps = alloc.vec(request.safepoint_insns.len());
+        for _ in 0..request.safepoint_insns.len() {
+            stackmaps.push(alloc.vec(4));
+        }
         for int in intervals {
             if !int.ref_typed {
                 continue;
@@ -870,24 +881,25 @@ fn compute_stackmaps(
         }
         stackmaps
     } else {
-        vec![]
+        alloc.vec(0)
     }
 }
 
 /// Fills in the register assignments into instructions.
 #[inline(never)]
-fn apply_registers<F: Function>(
+fn apply_registers<'a, F: Function>(
     func: &mut F,
-    virtual_intervals: &Vec<VirtualInterval>,
-    memory_moves: Vec<InstToInsertAndExtPoint>,
+    virtual_intervals: &[VirtualInterval],
+    memory_moves: &[InstToInsertAndExtPoint],
     reg_universe: &RealRegUniverse,
     num_spill_slots: u32,
     use_checker: bool,
     stackmap_request: Option<&StackmapRequestInfo>,
-) -> Result<RegAllocResult<F>, RegAllocError> {
+    alloc: &Alloc<'a>,
+) -> Result<RegAllocResult<'a, F>, RegAllocError> {
     info!("apply_registers");
 
-    let stackmaps = compute_stackmaps(virtual_intervals, stackmap_request.clone());
+    let stackmaps = compute_stackmaps(virtual_intervals, stackmap_request.clone(), alloc);
 
     let clobbered_registers = set_registers(
         func,
@@ -897,6 +909,7 @@ fn apply_registers<F: Function>(
         &memory_moves,
         stackmap_request,
         &stackmaps,
+        alloc,
     )
     .map_err(|err| RegAllocError::RegChecker(err))?;
 
@@ -904,19 +917,22 @@ fn apply_registers<F: Function>(
         add_spills_reloads_and_moves(
             func,
             stackmap_request.map(|request| request.safepoint_insns.as_slice()),
-            memory_moves,
+            &memory_moves[..],
+            alloc,
         )
         .map_err(|e| RegAllocError::Other(e))?;
 
     // And now remove from the clobbered registers set, all those not available to the allocator.
     // But not removing the reserved regs, since we might have modified those.
-    clobbered_registers.filter_map(|&reg| {
-        if reg.get_index() >= reg_universe.allocable {
-            None
-        } else {
-            Some(reg)
+    let clobbered_registers = {
+        let mut n = alloc.set(clobbered_registers.len());
+        for reg in clobbered_registers {
+            if reg.get_index() < reg_universe.allocable {
+                n.insert(reg);
+            }
         }
-    });
+        n
+    };
 
     Ok(RegAllocResult {
         insns: final_insns,

--- a/lib/src/linear_scan/resolve_moves.rs
+++ b/lib/src/linear_scan/resolve_moves.rs
@@ -6,32 +6,33 @@ use crate::{
     sparse_set::SparseSet,
     Function, RealReg, Reg, SpillSlot, TypedIxVec, VirtualReg, Writable,
 };
+use crate::{Alloc, BumpVec};
 
 use log::{debug, info, trace};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 use std::fmt;
 
-fn resolve_moves_in_block<F: Function>(
+fn resolve_moves_in_block<'a, F: Function>(
     func: &F,
-    intervals: &Vec<VirtualInterval>,
-    reg_uses: &RegUses,
+    intervals: &[VirtualInterval],
+    reg_uses: &RegUses<'a>,
     scratches_by_rc: &[Option<RealReg>],
     spill_slot: &mut u32,
-    moves_in_blocks: &mut Vec<InstToInsertAndExtPoint>,
-    tmp_ordered_moves: &mut Vec<MoveOp>,
-    tmp_stack: &mut Vec<MoveOp>,
+    moves_in_blocks: &mut BumpVec<'a, InstToInsertAndExtPoint>,
+    tmp_ordered_moves: &mut BumpVec<'a, MoveOp>,
+    tmp_stack: &mut BumpVec<'a, MoveOp>,
+    alloc: &Alloc<'a>,
 ) {
-    let mut block_ends = HashSet::default();
-    let mut block_starts = HashSet::default();
+    let mut block_ends = alloc.set(4);
+    let mut block_starts = alloc.set(4);
     for bix in func.blocks() {
         let insts = func.block_insns(bix);
         block_ends.insert(insts.last());
         block_starts.insert(insts.first());
     }
 
-    let mut reloads_at_inst = HashMap::default();
-    let mut spills_at_inst = Vec::new();
+    let mut reloads_at_inst = alloc.map(4);
+    let mut spills_at_inst = alloc.vec(0);
 
     for interval in intervals {
         let parent_id = match interval.parent {
@@ -89,7 +90,9 @@ fn resolve_moves_in_block<F: Function>(
                     _ => unreachable!(),
                 }
 
-                let entry = reloads_at_inst.entry(at_inst).or_insert_with(|| Vec::new());
+                let entry = reloads_at_inst
+                    .entry(at_inst)
+                    .or_insert_with(|| alloc.vec(0));
 
                 match parent.location {
                     Location::None => unreachable!(),
@@ -160,7 +163,7 @@ fn resolve_moves_in_block<F: Function>(
         schedule_moves(&mut pending_moves, tmp_ordered_moves, tmp_stack);
         emit_moves(
             at_inst,
-            &tmp_ordered_moves,
+            &tmp_ordered_moves[..],
             spill_slot,
             scratches_by_rc,
             moves_in_blocks,
@@ -226,14 +229,15 @@ impl BlockInfo {
 /// For each block, collect a mapping of block_{start, end} -> actual location, to make the
 /// across-blocks fixup phase fast.
 #[inline(never)]
-fn collect_block_infos<F: Function>(
+fn collect_block_infos<'a, F: Function>(
     func: &F,
-    intervals: &Vec<VirtualInterval>,
-    liveins: &TypedIxVec<BlockIx, SparseSet<Reg>>,
-    liveouts: &TypedIxVec<BlockIx, SparseSet<Reg>>,
-) -> Vec<BlockInfo> {
+    intervals: &[VirtualInterval],
+    liveins: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
+    liveouts: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
+    alloc: &Alloc<'a>,
+) -> BumpVec<'a, BlockInfo> {
     // Preallocate the block information, with the final size of each vector.
-    let mut infos = Vec::with_capacity(func.blocks().len());
+    let mut infos = alloc.vec(func.blocks().len());
     for bix in func.blocks() {
         infos.push(BlockInfo {
             start: SmallVec::with_capacity(liveins[bix].card()),
@@ -286,24 +290,25 @@ fn collect_block_infos<F: Function>(
 /// - resolve cycles in the pending moves
 /// - generate real moves from the pending moves.
 #[inline(never)]
-fn resolve_moves_across_blocks<F: Function>(
+fn resolve_moves_across_blocks<'a, F: Function>(
     func: &F,
-    cfg: &CFGInfo,
-    liveins: &TypedIxVec<BlockIx, SparseSet<Reg>>,
-    liveouts: &TypedIxVec<BlockIx, SparseSet<Reg>>,
-    intervals: &Vec<VirtualInterval>,
+    cfg: &CFGInfo<'a>,
+    liveins: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
+    liveouts: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
+    intervals: &[VirtualInterval],
     scratches_by_rc: &[Option<RealReg>],
     spill_slot: &mut u32,
-    moves_at_block_starts: &mut Vec<InstToInsertAndExtPoint>,
-    moves_at_block_ends: &mut Vec<InstToInsertAndExtPoint>,
-    tmp_ordered_moves: &mut Vec<MoveOp>,
-    tmp_stack: &mut Vec<MoveOp>,
+    moves_at_block_starts: &mut BumpVec<'a, InstToInsertAndExtPoint>,
+    moves_at_block_ends: &mut BumpVec<'a, InstToInsertAndExtPoint>,
+    tmp_ordered_moves: &mut BumpVec<'a, MoveOp>,
+    tmp_stack: &mut BumpVec<'a, MoveOp>,
+    alloc: &Alloc<'a>,
 ) {
-    let mut parallel_move_map = HashMap::default();
+    let mut parallel_move_map = alloc.map(4);
 
-    let block_info = collect_block_infos(func, intervals, liveins, liveouts);
+    let block_info = collect_block_infos(func, intervals, liveins, liveouts, alloc);
 
-    let mut seen_successors = HashSet::default();
+    let mut seen_successors = alloc.set(4);
     for block in func.blocks() {
         let successors = &cfg.succ_map[block];
 
@@ -365,7 +370,7 @@ fn resolve_moves_across_blocks<F: Function>(
 
                 let pending_moves = parallel_move_map
                     .entry(at_inst)
-                    .or_insert_with(|| (Vec::new(), block_pos));
+                    .or_insert_with(|| (alloc.vec(0), block_pos));
 
                 match (loc_at_cur_end, loc_at_succ_start) {
                     (Location::Reg(cur_rreg), Location::Reg(succ_rreg)) => {
@@ -442,7 +447,7 @@ fn resolve_moves_across_blocks<F: Function>(
                 BlockPos::Start => {
                     emit_moves(
                         *at_inst,
-                        &tmp_ordered_moves,
+                        &tmp_ordered_moves[..],
                         spill_slot,
                         scratches_by_rc,
                         moves_at_block_starts,
@@ -451,7 +456,7 @@ fn resolve_moves_across_blocks<F: Function>(
                 BlockPos::End => {
                     emit_moves(
                         *at_inst,
-                        &tmp_ordered_moves,
+                        &tmp_ordered_moves[..],
                         spill_slot,
                         scratches_by_rc,
                         moves_at_block_ends,
@@ -467,16 +472,17 @@ fn resolve_moves_across_blocks<F: Function>(
 }
 
 #[inline(never)]
-pub(crate) fn run<F: Function>(
+pub(crate) fn run<'a, F: Function>(
     func: &F,
-    cfg: &CFGInfo,
-    reg_uses: &RegUses,
-    intervals: &Vec<VirtualInterval>,
-    liveins: &TypedIxVec<BlockIx, SparseSet<Reg>>,
-    liveouts: &TypedIxVec<BlockIx, SparseSet<Reg>>,
+    cfg: &CFGInfo<'a>,
+    reg_uses: &RegUses<'a>,
+    intervals: &[VirtualInterval],
+    liveins: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
+    liveouts: &TypedIxVec<'a, BlockIx, SparseSet<Reg>>,
     spill_slot: &mut u32,
     scratches_by_rc: &[Option<RealReg>],
-) -> Vec<InstToInsertAndExtPoint> {
+    alloc: &Alloc<'a>,
+) -> BumpVec<'a, InstToInsertAndExtPoint> {
     info!("resolve_moves");
 
     // Keep three lists of moves to insert:
@@ -487,12 +493,12 @@ pub(crate) fn run<F: Function>(
     // To maintain the property that these moves are eventually sorted at the end, we'll compute
     // the final array of moves by concatenating these three arrays. `inst_stream` uses a stable
     // sort, making sure the at-block-start/within-block/at-block-end will be respected.
-    let mut moves_at_block_starts = Vec::new();
-    let mut moves_at_block_ends = Vec::new();
-    let mut moves_in_blocks = Vec::new();
+    let mut moves_at_block_starts = alloc.vec(16);
+    let mut moves_at_block_ends = alloc.vec(16);
+    let mut moves_in_blocks = alloc.vec(16);
 
-    let mut tmp_stack = Vec::new();
-    let mut tmp_ordered_moves = Vec::new();
+    let mut tmp_stack = alloc.vec(16);
+    let mut tmp_ordered_moves = alloc.vec(16);
     resolve_moves_in_block(
         func,
         intervals,
@@ -502,6 +508,7 @@ pub(crate) fn run<F: Function>(
         &mut moves_in_blocks,
         &mut tmp_ordered_moves,
         &mut tmp_stack,
+        alloc,
     );
 
     resolve_moves_across_blocks(
@@ -516,6 +523,7 @@ pub(crate) fn run<F: Function>(
         &mut moves_at_block_ends,
         &mut tmp_ordered_moves,
         &mut tmp_stack,
+        alloc,
     );
 
     let mut insts_and_points = moves_at_block_starts;
@@ -616,8 +624,8 @@ impl MoveOp {
     }
 }
 
-fn find_blocking_move<'a>(
-    pending: &'a mut Vec<MoveOp>,
+fn find_blocking_move<'a, 'arena>(
+    pending: &'a mut BumpVec<'arena, MoveOp>,
     last: &MoveOp,
 ) -> Option<(usize, &'a mut MoveOp)> {
     for (i, other) in pending.iter_mut().enumerate() {
@@ -628,8 +636,8 @@ fn find_blocking_move<'a>(
     None
 }
 
-fn find_cycled_move<'a>(
-    stack: &'a mut Vec<MoveOp>,
+fn find_cycled_move<'a, 'arena>(
+    stack: &'a mut BumpVec<'arena, MoveOp>,
     from: &mut usize,
     last: &MoveOp,
 ) -> Option<&'a mut MoveOp> {
@@ -646,10 +654,10 @@ fn find_cycled_move<'a>(
 /// Given a pending list of moves, returns a list of moves ordered in a correct
 /// way, i.e., no move clobbers another one.
 #[inline(never)]
-fn schedule_moves(
-    pending: &mut Vec<MoveOp>,
-    ordered_moves: &mut Vec<MoveOp>,
-    stack: &mut Vec<MoveOp>,
+fn schedule_moves<'a>(
+    pending: &mut BumpVec<'a, MoveOp>,
+    ordered_moves: &mut BumpVec<'a, MoveOp>,
+    stack: &mut BumpVec<'a, MoveOp>,
 ) {
     ordered_moves.clear();
 
@@ -721,12 +729,12 @@ fn schedule_moves(
 }
 
 #[inline(never)]
-fn emit_moves(
+fn emit_moves<'a>(
     at_inst: InstPoint,
-    ordered_moves: &Vec<MoveOp>,
+    ordered_moves: &[MoveOp],
     num_spill_slots: &mut u32,
     scratches_by_rc: &[Option<RealReg>],
-    moves_in_blocks: &mut Vec<InstToInsertAndExtPoint>,
+    moves_in_blocks: &mut BumpVec<'a, InstToInsertAndExtPoint>,
 ) {
     let mut spill_slot = None;
     let mut in_cycle = false;

--- a/lib/src/snapshot.rs
+++ b/lib/src/snapshot.rs
@@ -157,12 +157,17 @@ impl IRSnapshot {
         }
     }
 
-    pub fn allocate(&mut self, opts: Options) -> Result<RegAllocResult<IRFunction>, RegAllocError> {
+    pub fn allocate<'a>(
+        &mut self,
+        opts: Options,
+        alloc: &Alloc<'a>,
+    ) -> Result<RegAllocResult<'a, IRFunction>, RegAllocError> {
         allocate_registers_with_opts(
             &mut self.func,
             &self.reg_universe,
             None, /*no stackmap request*/
             opts,
+            alloc,
         )
     }
 }


### PR DESCRIPTION
This PR modifies both linear scan and BT allocators (and their shared
analyses) to pervasively use `bumpalo` for memory allocation from an
arena that lives for the duration of a function's register allocation.
This should result in significant performance improvements (I have not
yet measured, though), as we have seen malloc/free to be significant
parts of CPU-time profiles in the past.

Care must be taken to *not* use normal heap-allocated types inside of a
`BumpVec`, `BumpMap` or `BumpSet`, because the arena does not invoke
`Drop` impls when it is finally discarded (this is what allows freeing
the memory to be so fast; we just discard the entire block at once). As
such, many uses of `SmallVec` and some other types had to change. Some
cases that I had missed were picked up by LeakSanitizer in fuzzing runs,
and these errors no longer occur, so I'm relatively satisfied that we've
covered them all.

This changes the public interface -- the caller must provide the arena,
and some of the returned metadata is allocated within it -- so it will
require corresponding updates in e.g. Cranelift. That will come in
subsequent PRs.

Thanks to @bnjbvr for noting in our discussion this morning that memory
allocation is still significant in profiles and thus inspiring me to
dive into this :-)