### PR TITLE
Demote all logging statements from `info!` to `debug!`

### DIFF
--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1,6 +1,6 @@
 //! Performs dataflow and liveness analysis, including live range construction.
 
-use log::{trace, log_enabled, Level};
+use log::{log_enabled, trace, Level};
 use smallvec::{smallvec, SmallVec};
 use std::cmp::min;
 use std::fmt;
@@ -409,7 +409,10 @@ pub fn get_sanitized_reg_uses_for_func<F: Function>(
             );
             trace!(
                 "{:?}  SAN_RU: use {{ {}}} mod {{ {}}} def {{ {}}}",
-                iix, s_use, s_mod, s_def
+                iix,
+                s_use,
+                s_mod,
+                s_def
             );
         }
     }
@@ -711,7 +714,9 @@ pub fn calc_livein_and_liveout<F: Function>(
     let ratio: f32 = (num_evals as f32) / ((if num_blocks == 0 { 1 } else { num_blocks }) as f32);
     trace!(
         "    calc_livein_and_liveout:   {} blocks, {} evals ({:<.2} per block)",
-        num_blocks, num_evals, ratio
+        num_blocks,
+        num_evals,
+        ratio
     );
 
     if log_enabled!(Level::Trace) {
@@ -1523,7 +1528,8 @@ pub(crate) fn merge_range_frags(
     trace!("      in: {} in frag_env", frag_env.len());
     trace!(
         "      in: {} regs containing in total {} frags",
-        stats_num_total_incoming_regs, stats_num_total_incoming_frags
+        stats_num_total_incoming_regs,
+        stats_num_total_incoming_frags
     );
 
     let mut stats_num_single_grps = 0;
@@ -1784,11 +1790,13 @@ pub(crate) fn merge_range_frags(
     );
     trace!(
         "      in: {} small multi groups, {} small multi group total size",
-        stats_num_multi_grps_small, stats_size_multi_grps_small
+        stats_num_multi_grps_small,
+        stats_size_multi_grps_small
     );
     trace!(
         "      in: {} large multi groups, {} large multi group total size",
-        stats_num_multi_grps_large, stats_size_multi_grps_large
+        stats_num_multi_grps_large,
+        stats_size_multi_grps_large
     );
     trace!(
         "      out: {} VLRs, {} RLRs",
@@ -1797,7 +1805,8 @@ pub(crate) fn merge_range_frags(
     );
     trace!(
         "      compress vfrags: in {}, out {}",
-        stats_num_vfrags_uncompressed, stats_num_vfrags_compressed
+        stats_num_vfrags_uncompressed,
+        stats_num_vfrags_compressed
     );
     trace!("    merge_range_frags: end");
 

--- a/lib/src/analysis_data_flow.rs
+++ b/lib/src/analysis_data_flow.rs
@@ -1,6 +1,6 @@
 //! Performs dataflow and liveness analysis, including live range construction.
 
-use log::{debug, info, log_enabled, Level};
+use log::{trace, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
 use std::cmp::min;
 use std::fmt;
@@ -377,7 +377,7 @@ pub fn get_sanitized_reg_uses_for_func<F: Function>(
     assert!(!reg_vecs.is_sanitized());
     reg_vecs.set_sanitized(true);
 
-    if log_enabled!(Level::Debug) {
+    if log_enabled!(Level::Trace) {
         let show_reg = |r: Reg| {
             if r.is_real() {
                 reg_universe.regs[r.get_index()].1.clone()
@@ -407,7 +407,7 @@ pub fn get_sanitized_reg_uses_for_func<F: Function>(
                 &reg_vecs.defs[bounds_vec[iix].defs_start as usize
                     ..bounds_vec[iix].defs_start as usize + bounds_vec[iix].defs_len as usize],
             );
-            debug!(
+            trace!(
                 "{:?}  SAN_RU: use {{ {}}} mod {{ {}}} def {{ {}}}",
                 iix, s_use, s_mod, s_def
             );
@@ -520,7 +520,7 @@ pub fn calc_def_and_use<F: Function>(
     TypedIxVec<BlockIx, SparseSet<Reg>>,
     TypedIxVec<BlockIx, SparseSet<Reg>>,
 ) {
-    info!("    calc_def_and_use: begin");
+    trace!("    calc_def_and_use: begin");
     assert!(rvb.is_sanitized());
     let mut def_sets = TypedIxVec::new();
     let mut use_sets = TypedIxVec::new();
@@ -578,9 +578,9 @@ pub fn calc_def_and_use<F: Function>(
 
     assert!(def_sets.len() == use_sets.len());
 
-    if log_enabled!(Level::Debug) {
+    if log_enabled!(Level::Trace) {
         let mut n = 0;
-        debug!("");
+        trace!("");
         for (def_set, use_set) in def_sets.iter().zip(use_sets.iter()) {
             let mut first = true;
             let mut defs_str = "".to_string();
@@ -600,7 +600,7 @@ pub fn calc_def_and_use<F: Function>(
                 first = false;
                 uses_str = uses_str + &uce.show_with_rru(univ);
             }
-            debug!(
+            trace!(
                 "{:<3?}   def {{{}}}  use {{{}}}",
                 BlockIx::new(n),
                 defs_str,
@@ -610,7 +610,7 @@ pub fn calc_def_and_use<F: Function>(
         }
     }
 
-    info!("    calc_def_and_use: end");
+    trace!("    calc_def_and_use: end");
     (def_sets, use_sets)
 }
 
@@ -630,7 +630,7 @@ pub fn calc_livein_and_liveout<F: Function>(
     TypedIxVec<BlockIx, SparseSet<Reg>>,
     TypedIxVec<BlockIx, SparseSet<Reg>>,
 ) {
-    info!("    calc_livein_and_liveout: begin");
+    trace!("    calc_livein_and_liveout: begin");
     let num_blocks = func.blocks().len() as u32;
     let empty = SparseSet::<Reg>::empty();
 
@@ -709,14 +709,14 @@ pub fn calc_livein_and_liveout<F: Function>(
     }
 
     let ratio: f32 = (num_evals as f32) / ((if num_blocks == 0 { 1 } else { num_blocks }) as f32);
-    info!(
+    trace!(
         "    calc_livein_and_liveout:   {} blocks, {} evals ({:<.2} per block)",
         num_blocks, num_evals, ratio
     );
 
-    if log_enabled!(Level::Debug) {
+    if log_enabled!(Level::Trace) {
         let mut n = 0;
-        debug!("");
+        trace!("");
         for (livein, liveout) in liveins.iter().zip(liveouts.iter()) {
             let mut first = true;
             let mut li_str = "".to_string();
@@ -736,7 +736,7 @@ pub fn calc_livein_and_liveout<F: Function>(
                 first = false;
                 lo_str = lo_str + &lo.show_with_rru(univ);
             }
-            debug!(
+            trace!(
                 "{:<3?}   livein {{{}}}  liveout {{{}}}",
                 BlockIx::new(n),
                 li_str,
@@ -746,7 +746,7 @@ pub fn calc_livein_and_liveout<F: Function>(
         }
     }
 
-    info!("    calc_livein_and_liveout: end");
+    trace!("    calc_livein_and_liveout: end");
     (liveins, liveouts)
 }
 
@@ -1146,7 +1146,7 @@ pub fn get_range_frags<F: Function>(
     TypedIxVec<RangeFragIx, RangeFragMetrics>,
     Vec</*vreg index,*/ RegClass>,
 ) {
-    info!("    get_range_frags: begin");
+    trace!("    get_range_frags: begin");
     assert!(livein_sets_per_block.len() == func.blocks().len() as u32);
     assert!(liveout_sets_per_block.len() == func.blocks().len() as u32);
     assert!(rvb.is_sanitized());
@@ -1224,21 +1224,21 @@ pub fn get_range_frags<F: Function>(
         assert!(state_elem.is_none());
     }
 
-    if log_enabled!(Level::Debug) {
-        debug!("");
+    if log_enabled!(Level::Trace) {
+        trace!("");
         let mut n = 0;
         for frag in result_frags.iter() {
-            debug!("{:<3?}   {:?}", RangeFragIx::new(n), frag);
+            trace!("{:<3?}   {:?}", RangeFragIx::new(n), frag);
             n += 1;
         }
 
-        debug!("");
+        trace!("");
         for (reg_ix, frag_ixs) in result_map.iter().enumerate() {
             if frag_ixs.len() == 0 {
                 continue;
             }
             let reg = reg_ix_to_reg(reg_universe, &vreg_classes, reg_ix as u32);
-            debug!(
+            trace!(
                 "frags for {}   {:?}",
                 reg.show_with_rru(reg_universe),
                 frag_ixs
@@ -1246,7 +1246,7 @@ pub fn get_range_frags<F: Function>(
         }
     }
 
-    info!("    get_range_frags: end");
+    trace!("    get_range_frags: end");
     assert!(result_frags.len() == result_frag_metrics.len());
     (result_map, result_frags, result_frag_metrics, vreg_classes)
 }
@@ -1519,9 +1519,9 @@ pub(crate) fn merge_range_frags(
             stats_num_total_incoming_regs += 1;
         }
     }
-    info!("    merge_range_frags: begin");
-    info!("      in: {} in frag_env", frag_env.len());
-    info!(
+    trace!("    merge_range_frags: begin");
+    trace!("      in: {} in frag_env", frag_env.len());
+    trace!(
         "      in: {} regs containing in total {} frags",
         stats_num_total_incoming_regs, stats_num_total_incoming_frags
     );
@@ -1777,29 +1777,29 @@ pub(crate) fn merge_range_frags(
         // END merge `all_frag_ixs_for_reg` entries as much as possible
     } // END per reg loop
 
-    info!("      in: {} single groups", stats_num_single_grps);
-    info!(
+    trace!("      in: {} single groups", stats_num_single_grps);
+    trace!(
         "      in: {} local frags in multi groups",
         stats_num_local_frags
     );
-    info!(
+    trace!(
         "      in: {} small multi groups, {} small multi group total size",
         stats_num_multi_grps_small, stats_size_multi_grps_small
     );
-    info!(
+    trace!(
         "      in: {} large multi groups, {} large multi group total size",
         stats_num_multi_grps_large, stats_size_multi_grps_large
     );
-    info!(
+    trace!(
         "      out: {} VLRs, {} RLRs",
         result_virtual.len(),
         result_real.len()
     );
-    info!(
+    trace!(
         "      compress vfrags: in {}, out {}",
         stats_num_vfrags_uncompressed, stats_num_vfrags_compressed
     );
-    info!("    merge_range_frags: end");
+    trace!("    merge_range_frags: end");
 
     (result_real, result_virtual)
 }

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -1,6 +1,6 @@
 //! Top level module for all analysis activities.
 
-use log::{debug, info};
+use log::trace;
 
 use crate::data_structures::*;
 use crate::sparse_set::SparseSet;
@@ -139,8 +139,8 @@ pub fn run_analysis<F: Function>(
     reftype_class: RegClass,
     reftyped_vregs: &Vec<VirtualReg>, // as supplied by the client
 ) -> Result<AnalysisInfo, AnalysisError> {
-    info!("run_analysis: begin");
-    info!(
+    trace!("run_analysis: begin");
+    trace!(
         "  run_analysis: {} blocks, {} insns",
         func.blocks().len(),
         func.insns().len()
@@ -149,7 +149,7 @@ pub fn run_analysis<F: Function>(
     // LSRA uses its own analysis.
     assert!(!client_wants_stackmaps || algorithm != AlgorithmWithDefaults::LinearScan);
 
-    info!("  run_analysis: begin control flow analysis");
+    trace!("  run_analysis: begin control flow analysis");
 
     // First do control flow analysis.  This is (relatively) simple.  Note that
     // this can fail, for various reasons; we propagate the failure if so.
@@ -162,10 +162,10 @@ pub fn run_analysis<F: Function>(
     // Annotate each Block with its estimated execution frequency.
     let estimated_frequencies = DepthBasedFrequencies::new(func, &cfg_info);
 
-    info!("  run_analysis: end control flow analysis");
+    trace!("  run_analysis: end control flow analysis");
 
     // Now perform dataflow analysis.  This is somewhat more complex.
-    info!("  run_analysis: begin data flow analysis");
+    trace!("  run_analysis: begin data flow analysis");
 
     // See `get_sanitized_reg_uses_for_func` for the meaning of "sanitized".
     let reg_vecs_and_bounds = get_sanitized_reg_uses_for_func(func, reg_universe)
@@ -222,13 +222,13 @@ pub fn run_analysis<F: Function>(
         }
     }
 
-    info!("  run_analysis: end data flow analysis");
+    trace!("  run_analysis: end data flow analysis");
 
     // Dataflow analysis is now complete.  Now compute the virtual and real live
     // ranges, in two steps: (1) compute RangeFrags, and (2) merge them
     // together, guided by flow and liveness info, so as to create the final
     // VirtualRanges and RealRanges.
-    info!("  run_analysis: begin liveness analysis");
+    trace!("  run_analysis: begin liveness analysis");
 
     let (frag_ixs_per_reg, frag_env, frag_metrics_env, vreg_classes) = get_range_frags(
         func,
@@ -252,10 +252,10 @@ pub fn run_analysis<F: Function>(
 
     debug_assert!(liveout_sets_per_block.len() == estimated_frequencies.len());
 
-    debug!("");
+    trace!("");
     let mut n = 0;
     for rlr in rlr_env.iter() {
-        debug!(
+        trace!(
             "{:<4?}   {}",
             RealRangeIx::new(n),
             rlr.show_with_rru(&reg_universe)
@@ -263,10 +263,10 @@ pub fn run_analysis<F: Function>(
         n += 1;
     }
 
-    debug!("");
+    trace!("");
     n = 0;
     for vlr in vlr_env.iter() {
-        debug!("{:<4?}   {:?}", VirtualRangeIx::new(n), vlr);
+        trace!("{:<4?}   {:?}", VirtualRangeIx::new(n), vlr);
         n += 1;
     }
 
@@ -293,10 +293,10 @@ pub fn run_analysis<F: Function>(
             (None, None)
         };
 
-    info!("  run_analysis: end liveness analysis");
+    trace!("  run_analysis: end liveness analysis");
 
     if client_wants_stackmaps {
-        info!("  run_analysis: begin reftypes analysis");
+        trace!("  run_analysis: begin reftypes analysis");
         do_reftypes_analysis(
             &mut rlr_env,
             &mut vlr_env,
@@ -306,10 +306,10 @@ pub fn run_analysis<F: Function>(
             reftype_class,
             reftyped_vregs,
         );
-        info!("  run_analysis: end reftypes analysis");
+        trace!("  run_analysis: end reftypes analysis");
     }
 
-    info!("run_analysis: end");
+    trace!("run_analysis: end");
 
     Ok(AnalysisInfo {
         reg_vecs_and_bounds,
@@ -390,12 +390,12 @@ impl<'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'a> {
         if range.is_real() {
             let rrange = &mut self.rlr_env[range.to_real()];
             debug_assert!(!rrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", range.to_real());
+            trace!(" -> rrange {:?} is reffy", range.to_real());
             rrange.is_ref = true;
         } else {
             let vrange = &mut self.vlr_env[range.to_virtual()];
             debug_assert!(!vrange.is_ref);
-            debug!(" -> rrange {:?} is reffy", range.to_virtual());
+            trace!(" -> rrange {:?} is reffy", range.to_virtual());
             vrange.is_ref = true;
         }
     }
@@ -403,7 +403,7 @@ impl<'a> ReftypeAnalysis for BacktrackingReftypeAnalysis<'a> {
     #[inline(always)]
     fn insert_reffy_ranges(&self, vreg: VirtualReg, set: &mut SparseSet<Self::RangeId>) {
         for vlr_ix in &self.reg_to_ranges_maps.vreg_to_vlrs_map[vreg.get_index()] {
-            debug!("range {:?} is reffy due to reffy vreg {:?}", vlr_ix, vreg);
+            trace!("range {:?} is reffy due to reffy vreg {:?}", vlr_ix, vreg);
             set.insert(RangeId::new_virtual(*vlr_ix));
         }
     }

--- a/lib/src/analysis_main.rs
+++ b/lib/src/analysis_main.rs
@@ -79,26 +79,22 @@ impl ToString for AnalysisError {
                     regs_string
                 )
             }
-            AnalysisError::IllegalRealReg(reg) => {
-                format!(
-                    "instructions mention real register {:?}, which either isn't defined in the
+            AnalysisError::IllegalRealReg(reg) => format!(
+                "instructions mention real register {:?}, which either isn't defined in the
                     register universe, or is a 'suggested_scratch' register",
-                    reg
-                )
-            }
+                reg
+            ),
             AnalysisError::UnreachableBlocks => "at least one block is unreachable".to_string(),
             AnalysisError::ImplementationLimitsExceeded => {
                 "implementation limits exceeded (more than 1 million blocks or 16 million insns)"
                     .to_string()
             }
-            AnalysisError::LsraCriticalEdge { block, inst } => {
-                format!(
-                    "block {:?} ends with control flow instruction {:?} that mentions a register,
+            AnalysisError::LsraCriticalEdge { block, inst } => format!(
+                "block {:?} ends with control flow instruction {:?} that mentions a register,
                     and at least one of the multiple successors has several predecessors; consider
                     splitting the outgoing edges!",
-                    block, inst
-                )
-            }
+                block, inst
+            ),
         }
     }
 }

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -26,7 +26,7 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use log::{debug, info, log_enabled, Level};
+use log::{trace, log_enabled, Level};
 use smallvec::{smallvec, SmallVec};
 
 use crate::data_structures::{
@@ -144,8 +144,8 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
     UnionFindEquivClasses<VirtualRangeIx>,
     TypedIxVec<InstIx, bool>,
 ) {
-    info!("");
-    info!("do_coalescing_analysis: begin");
+    trace!("");
+    trace!("do_coalescing_analysis: begin");
 
     // This function contains significant additional complexity due to the requirement to handle
     // pathological cases in reasonable time without unduly burdening the common cases.
@@ -535,7 +535,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
         ..
     } in move_info.iter()
     {
-        debug!(
+        trace!(
             "connected by moves: {:?} {:?} <- {:?} (est_freq {})",
             iix, dst, src, est_freq
         );
@@ -565,7 +565,7 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
                         // both `vlrixSrc` and `vlrixDst`.  This is so as to reduce to
                         // zero, the cost of a VLR whose only instructions are its
                         // v-v boundary copies.
-                        debug!("reduce cost of {:?} and {:?}", vlrixSrc, vlrixDst);
+                        trace!("reduce cost of {:?} and {:?}", vlrixSrc, vlrixDst);
                         decVLRcosts.push((vlrixSrc, vlrixDst, 1 * est_freq));
                     }
                 }
@@ -633,22 +633,22 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
     let vlrEquivClasses: UnionFindEquivClasses<VirtualRangeIx> =
         vlrEquivClassesUF.get_equiv_classes();
 
-    if log_enabled!(Level::Debug) {
-        debug!("Revised VLRs:");
+    if log_enabled!(Level::Trace) {
+        trace!("Revised VLRs:");
         let mut n = 0;
         for vlr in vlr_env.iter() {
-            debug!("{:<4?}   {:?}", VirtualRangeIx::new(n), vlr);
+            trace!("{:<4?}   {:?}", VirtualRangeIx::new(n), vlr);
             n += 1;
         }
 
-        debug!("Coalescing hints:");
+        trace!("Coalescing hints:");
         n = 0;
         for hints_for_one_vlr in hints.iter() {
             let mut s = "".to_string();
             for hint in hints_for_one_vlr {
                 s = s + &show_hint(hint, &univ) + &" ".to_string();
             }
-            debug!("  hintsfor {:<4?} = {}", VirtualRangeIx::new(n), s);
+            trace!("  hintsfor {:<4?} = {}", VirtualRangeIx::new(n), s);
             n += 1;
         }
 
@@ -659,18 +659,18 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
                 tmpvec.reverse();
                 tmpvec.push(elem);
             }
-            debug!("  eclassof {:?} = {:?}", vlrix, tmpvec);
+            trace!("  eclassof {:?} = {:?}", vlrix, tmpvec);
         }
 
         for (b, i) in is_vv_boundary_move.iter().zip(0..) {
             if *b {
-                debug!("  vv_boundary_move at {:?}", InstIx::new(i));
+                trace!("  vv_boundary_move at {:?}", InstIx::new(i));
             }
         }
     }
 
-    info!("do_coalescing_analysis: end");
-    info!("");
+    trace!("do_coalescing_analysis: end");
+    trace!("");
 
     (hints, vlrEquivClasses, is_vv_boundary_move)
 }

--- a/lib/src/bt_coalescing_analysis.rs
+++ b/lib/src/bt_coalescing_analysis.rs
@@ -26,7 +26,7 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use log::{trace, log_enabled, Level};
+use log::{log_enabled, trace, Level};
 use smallvec::{smallvec, SmallVec};
 
 use crate::data_structures::{
@@ -537,7 +537,10 @@ pub(crate) fn do_coalescing_analysis<F: Function>(
     {
         trace!(
             "connected by moves: {:?} {:?} <- {:?} (est_freq {})",
-            iix, dst, src, est_freq
+            iix,
+            dst,
+            src,
+            est_freq
         );
         match (dst.is_virtual(), src.is_virtual()) {
             (true, true) => {

--- a/lib/src/bt_main.rs
+++ b/lib/src/bt_main.rs
@@ -3,7 +3,7 @@
 
 //! Core implementation of the backtracking allocator.
 
-use log::{debug, info, log_enabled, Level};
+use log::{debug, log_enabled, Level};
 use smallvec::SmallVec;
 use std::default;
 use std::fmt;
@@ -723,14 +723,14 @@ pub fn alloc_main<F: Function>(
     // -------- Alloc main --------
 
     // Create initial state
-    info!("alloc_main: begin");
-    info!(
+    debug!("alloc_main: begin");
+    debug!(
         "alloc_main:   in: {} insns in {} blocks",
         func.insns().len(),
         func.blocks().len()
     );
     let num_vlrs_initial = vlr_env.len();
-    info!(
+    debug!(
         "alloc_main:   in: {} VLRs, {} RLRs",
         num_vlrs_initial,
         rlr_env.len()
@@ -798,7 +798,7 @@ pub fn alloc_main<F: Function>(
     debug!("");
     debug!("-- MAIN ALLOCATION LOOP (DI means 'direct', CO means 'coalesced'):");
 
-    info!("alloc_main:   main allocation loop: begin");
+    debug!("alloc_main:   main allocation loop: begin");
 
     // ======== BEGIN Main allocation loop ========
     let mut num_vlrs_processed = 0; // stats only
@@ -1396,7 +1396,7 @@ pub fn alloc_main<F: Function>(
     }
     // ======== END Main allocation loop ========
 
-    info!("alloc_main:   main allocation loop: end");
+    debug!("alloc_main:   main allocation loop: end");
 
     if log_enabled!(Level::Debug) {
         debug!("");
@@ -1415,7 +1415,7 @@ pub fn alloc_main<F: Function>(
     // ======== BEGIN Do spill slot coalescing ========
 
     debug!("");
-    info!("alloc_main:   create spills_n_reloads for MOVE insns");
+    debug!("alloc_main:   create spills_n_reloads for MOVE insns");
 
     // Sort `edit_list_move` by the insn with which each item is associated.
     edit_list_move.sort_unstable_by(|eli1, eli2| eli1.iix.cmp(&eli2.iix));
@@ -1559,7 +1559,7 @@ pub fn alloc_main<F: Function>(
     // ======== BEGIN Create all other spills and reloads ========
 
     debug!("");
-    info!("alloc_main:   create spills_n_reloads for other insns");
+    debug!("alloc_main:   create spills_n_reloads for other insns");
 
     // Reload and spill instructions are missing.  To generate them, go through
     // the "edit list", which contains info on both how to generate the
@@ -1642,7 +1642,7 @@ pub fn alloc_main<F: Function>(
     // not take account of spill or reload instructions.  Dealing with those
     // is relatively simple and happens later.
 
-    info!("alloc_main:   create frag_map");
+    debug!("alloc_main:   create frag_map");
 
     let mut frag_map = Vec::<(RangeFrag, VirtualReg, RealReg)>::new();
     // For each real register under our control ..
@@ -1667,7 +1667,7 @@ pub fn alloc_main<F: Function>(
     let mut stackmaps = Vec::<Vec<SpillSlot>>::new();
 
     if !safepoint_insns.is_empty() {
-        info!("alloc_main:   create safepoints and stackmaps");
+        debug!("alloc_main:   create safepoints and stackmaps");
         for safepoint_iix in safepoint_insns {
             // Create the stackmap artefacts for `safepoint_iix`.  Save the stackmap (the
             // reftyped spillslots); we'll have to return it to the client as part of the
@@ -1716,7 +1716,7 @@ pub fn alloc_main<F: Function>(
         }
     }
 
-    info!("alloc_main:   edit_inst_stream");
+    debug!("alloc_main:   edit_inst_stream");
 
     let final_insns_and_targetmap_and_new_safepoints__or_err = edit_inst_stream(
         func,
@@ -1735,39 +1735,39 @@ pub fn alloc_main<F: Function>(
 
     match final_insns_and_targetmap_and_new_safepoints__or_err {
         Ok((ref final_insns, ..)) => {
-            info!(
+            debug!(
                 "alloc_main:   out: VLRs: {} initially, {} processed",
                 num_vlrs_initial, num_vlrs_processed
             );
-            info!(
+            debug!(
                 "alloc_main:   out: VLRs: {} evicted, {} spilled",
                 num_vlrs_evicted, num_vlrs_spilled
             );
-            info!(
+            debug!(
                 "alloc_main:   out: insns: {} total, {} spills, {} reloads, {} nopzs",
                 final_insns.len(),
                 num_spills,
                 num_reloads,
                 iixs_to_nop_out.len()
             );
-            info!(
+            debug!(
                 "alloc_main:   out: spill slots: {} used",
                 spill_slot_allocator.num_slots_in_use()
             );
         }
         Err(_) => {
-            info!("alloc_main:   allocation failed!");
+            debug!("alloc_main:   allocation failed!");
         }
     }
 
     let (final_insns, target_map, new_to_old_insn_map, new_safepoint_insns) =
         match final_insns_and_targetmap_and_new_safepoints__or_err {
             Err(e) => {
-                info!("alloc_main: fail");
+                debug!("alloc_main: fail");
                 return Err(e);
             }
             Ok(quad) => {
-                info!("alloc_main:   creating RegAllocResult");
+                debug!("alloc_main:   creating RegAllocResult");
                 quad
             }
         };
@@ -1835,7 +1835,7 @@ pub fn alloc_main<F: Function>(
         new_safepoint_insns,
     };
 
-    info!("alloc_main: end");
+    debug!("alloc_main: end");
 
     // ======== END Create the RegAllocResult ========
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,7 +32,7 @@ mod snapshot;
 mod sparse_set;
 mod union_find;
 
-use log::{info, log_enabled, Level};
+use log::{debug, log_enabled, Level};
 use std::default;
 use std::{borrow::Cow, fmt};
 
@@ -522,15 +522,15 @@ pub fn allocate_registers_with_opts<F: Function>(
     stackmap_info: Option<&StackmapRequestInfo>,
     opts: Options,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
-    info!("");
-    info!("================ regalloc.rs: BEGIN function ================");
+    debug!("");
+    debug!("================ regalloc.rs: BEGIN function ================");
 
-    if log_enabled!(Level::Info) {
-        info!("with options: {:?}", opts);
+    if log_enabled!(Level::Debug) {
+        debug!("with options: {:?}", opts);
         let strs = rreg_universe.show();
-        info!("using RealRegUniverse:");
+        debug!("using RealRegUniverse:");
         for s in strs {
-            info!("  {}", s);
+            debug!("  {}", s);
         }
     }
 
@@ -599,7 +599,7 @@ pub fn allocate_registers_with_opts<F: Function>(
         }
     };
 
-    info!("================ regalloc.rs: END function ================");
+    debug!("================ regalloc.rs: END function ================");
     res
 }
 

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -341,7 +341,8 @@ impl<'a> ReftypeAnalysis for LsraReftypeAnalysis<'a> {
         for vrange in &self.vreg_to_vranges[vreg.get_index()] {
             trace!(
                 "range {:?} is reffy due to reffy vreg {:?}",
-                vrange.int, vreg
+                vrange.int,
+                vreg
             );
             set.insert(RangeId::Virtual(vrange.int.0));
         }

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -13,7 +13,7 @@ use crate::{
     union_find::UnionFind,
     AnalysisError, Function, RealRegUniverse, RegClass, StackmapRequestInfo, TypedIxVec,
 };
-use log::{debug, info, log_enabled, trace, Level};
+use log::{log_enabled, trace, Level};
 use smallvec::{smallvec, SmallVec};
 use std::{cmp::Ordering, fmt, mem};
 
@@ -138,7 +138,7 @@ pub(crate) fn run<F: Function>(
     reg_universe: &RealRegUniverse,
     stackmap_request: Option<&StackmapRequestInfo>,
 ) -> Result<AnalysisInfo, AnalysisError> {
-    info!(
+    trace!(
         "run_analysis: begin: {} blocks, {} insns",
         func.blocks().len(),
         func.insns().len()
@@ -148,12 +148,12 @@ pub(crate) fn run<F: Function>(
     // various reasons; we propagate the failure if so.  Also create the InstIx-to-BlockIx map;
     // this isn't really control-flow analysis, but needs to be done at some point.
 
-    info!("  run_analysis: begin control flow analysis");
+    trace!("  run_analysis: begin control flow analysis");
     let cfg_info = CFGInfo::create(func)?;
     let inst_to_block_map = InstIxToBlockIxMap::new(func);
-    info!("  run_analysis: end control flow analysis");
+    trace!("  run_analysis: end control flow analysis");
 
-    info!("  run_analysis: begin data flow analysis");
+    trace!("  run_analysis: begin data flow analysis");
 
     // See `get_sanitized_reg_uses_for_func` for the meaning of "sanitized".
     let reg_vecs_and_bounds = get_sanitized_reg_uses_for_func(func, reg_universe)
@@ -228,9 +228,9 @@ pub(crate) fn run<F: Function>(
         }
     }
 
-    info!("  run_analysis: end data flow analysis");
+    trace!("  run_analysis: end data flow analysis");
 
-    info!("  run_analysis: begin liveness analysis");
+    trace!("  run_analysis: begin liveness analysis");
     let (frag_ixs_per_reg, mut frag_env, frag_metrics_env, vreg_classes) = get_range_frags(
         func,
         &reg_universe,
@@ -250,7 +250,7 @@ pub(crate) fn run<F: Function>(
         &vreg_classes,
         stackmap_request.is_some(),
     )?;
-    info!("  run_analysis: end liveness analysis");
+    trace!("  run_analysis: end liveness analysis");
 
     // Make sure the fixed interval's fragment are sorted, to allow for binary search in misc
     // contexts.
@@ -278,7 +278,7 @@ pub(crate) fn run<F: Function>(
         fixeds: fixed_intervals,
     };
 
-    info!("run_analysis: end");
+    trace!("run_analysis: end");
 
     Ok(AnalysisInfo {
         cfg: cfg_info,
@@ -339,7 +339,7 @@ impl<'a> ReftypeAnalysis for LsraReftypeAnalysis<'a> {
 
     fn insert_reffy_ranges(&self, vreg: VirtualReg, set: &mut SparseSet<Self::RangeId>) {
         for vrange in &self.vreg_to_vranges[vreg.get_index()] {
-            debug!(
+            trace!(
                 "range {:?} is reffy due to reffy vreg {:?}",
                 vrange.int, vreg
             );
@@ -652,7 +652,7 @@ fn get_range_frags<F: Function>(
     Vec<RangeFragMetrics>,
     Vec</*vreg index,*/ RegClass>,
 ) {
-    info!("    get_range_frags: begin");
+    trace!("    get_range_frags: begin");
     debug_assert!(liveins.len() == func.blocks().len() as u32);
     debug_assert!(liveouts.len() == func.blocks().len() as u32);
     debug_assert!(rvb.is_sanitized());
@@ -715,21 +715,21 @@ fn get_range_frags<F: Function>(
         assert!(state_elem.is_none());
     }
 
-    if log_enabled!(Level::Debug) {
-        debug!("");
+    if log_enabled!(Level::Trace) {
+        trace!("");
         let mut n = 0;
         for frag in result_frags.iter() {
-            debug!("{:<3?}   {:?}", RangeFragIx::new(n), frag);
+            trace!("{:<3?}   {:?}", RangeFragIx::new(n), frag);
             n += 1;
         }
 
-        debug!("");
+        trace!("");
         for (reg_ix, frag_ixs) in result_map.iter().enumerate() {
             if frag_ixs.len() == 0 {
                 continue;
             }
             let reg = reg_ix_to_reg(reg_universe, &vreg_classes, reg_ix as u32);
-            debug!(
+            trace!(
                 "frags for {}   {:?}",
                 reg.show_with_rru(reg_universe),
                 frag_ixs
@@ -737,7 +737,7 @@ fn get_range_frags<F: Function>(
         }
     }
 
-    info!("    get_range_frags: end");
+    trace!("    get_range_frags: end");
     assert!(result_frags.len() == result_frag_metrics.len());
 
     (result_map, result_frags, result_frag_metrics, vreg_classes)
@@ -762,14 +762,14 @@ fn merge_range_frags<F: Function>(
     vreg_classes: &Vec</*vreg index,*/ RegClass>,
     wants_stackmaps: bool,
 ) -> Result<(Vec<FixedInterval>, Vec<VirtualInterval>, VirtualRegToRanges), AnalysisError> {
-    info!("    merge_range_frags: begin");
-    if log_enabled!(Level::Info) {
+    trace!("    merge_range_frags: begin");
+    if log_enabled!(Level::Trace) {
         let mut stats_num_total_incoming_frags = 0;
         for all_frag_ixs_for_reg in frag_ix_vec_per_reg.iter() {
             stats_num_total_incoming_frags += all_frag_ixs_for_reg.len();
         }
-        info!("      in: {} in frag_env", frag_env.len());
-        info!(
+        trace!("      in: {} in frag_env", frag_env.len());
+        trace!(
             "      in: {} regs containing in total {} frags",
             frag_ix_vec_per_reg.len(),
             stats_num_total_incoming_frags
@@ -1031,7 +1031,7 @@ fn merge_range_frags<F: Function>(
         }
     }
 
-    info!("    merge_range_frags: end");
+    trace!("    merge_range_frags: end");
 
     Ok((result_fixed, result_virtual, vreg_to_vranges))
 }

--- a/lib/src/linear_scan/assign_registers.rs
+++ b/lib/src/linear_scan/assign_registers.rs
@@ -8,7 +8,7 @@ use crate::{
     VirtualReg, NUM_REG_CLASSES,
 };
 
-use log::{trace, log_enabled, Level};
+use log::{debug, info, log_enabled, trace, Level};
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 use std::collections::BinaryHeap;
@@ -204,7 +204,7 @@ pub(crate) fn run<F: Function>(
     let mut prev_start = InstPoint::min_value();
 
     while let Some(id) = state.next_unhandled() {
-        trace!("main loop: allocating {}", state.intervals.get(id));
+        debug!("main loop: allocating {}", state.intervals.get(id));
 
         #[cfg(debug_assertions)]
         {
@@ -237,15 +237,15 @@ pub(crate) fn run<F: Function>(
             reusable.computed_inactive = false;
         }
 
-        trace!("");
+        debug!("");
     }
 
-    if log_enabled!(Level::Trace) {
-        trace!("allocation results (in order):");
+    if log_enabled!(Level::Debug) {
+        debug!("allocation results (in order):");
         for int in state.intervals.virtuals.iter() {
-            trace!("{}", int);
+            debug!("{}", int);
         }
-        trace!("");
+        debug!("");
     }
 
     Ok((state.intervals, state.next_spill_slot.get()))
@@ -506,7 +506,7 @@ impl<'a, F: Function> State<'a, F> {
     fn spill(&mut self, id: IntId) {
         let int = self.intervals.get(id);
         debug_assert!(int.location.spill().is_none(), "already spilled");
-        trace!("spilling {:?}", id);
+        debug!("spilling {:?}", id);
 
         let vreg = int.vreg;
         let spill_slot = if let Some(spill_slot) = self.spill_map.get(&vreg) {
@@ -680,10 +680,10 @@ fn try_allocate_reg<F: Function>(
     let (best_reg, best_pos) = if let Some(solution) = select_naive_reg(reusable, state, id) {
         solution
     } else {
-        trace!("try_allocate_reg: all registers taken, need to spill.");
+        debug!("try_allocate_reg: all registers taken, need to spill.");
         return false;
     };
-    trace!(
+    debug!(
         "try_allocate_reg: best register {:?} has next use at {:?}",
         best_reg, best_pos
     );
@@ -695,7 +695,7 @@ fn try_allocate_reg<F: Function>(
     }
 
     // At least a partial match: allocate.
-    trace!(
+    debug!(
         "{:?}: {:?} <- {:?}",
         id,
         state.intervals.get(id).vreg,
@@ -829,7 +829,7 @@ fn allocate_blocked_reg<F: Function>(
             }
         }
     };
-    trace!(
+    debug!(
         "selecting blocked register {:?} with furthest next use at {:?}",
         best_reg, next_use_pos[best_reg]
     );
@@ -837,7 +837,7 @@ fn allocate_blocked_reg<F: Function>(
     // Step 3: if the next use of the current interval is after the furthest use
     // of the selected register, then we should spill the current interval.
     // Otherwise, spill other intervals.
-    trace!(
+    debug!(
         "current first used at {:?}, next use of best reg at {:?}",
         first_use, next_use_pos[best_reg]
     );
@@ -846,12 +846,12 @@ fn allocate_blocked_reg<F: Function>(
         if first_use == start_pos {
             return Err(RegAllocError::OutOfRegisters(reg_class));
         }
-        trace!("spill current interval");
+        debug!("spill current interval");
         let new_int = split(state, cur_id, first_use);
         state.insert_unhandled(new_int);
         state.spill(cur_id);
     } else {
-        trace!("taking over register, spilling intersecting intervals");
+        debug!("taking over register, spilling intersecting intervals");
 
         // Spill intervals that currently block the selected register.
         state.intervals.set_reg(cur_id, best_reg);
@@ -860,7 +860,7 @@ fn allocate_blocked_reg<F: Function>(
         // intersection.
         let int_end = state.intervals.get(cur_id).end;
         if block_pos[best_reg] <= int_end {
-            trace!(
+            debug!(
                 "allocate_blocked_reg: fixed conflict! blocked at {:?}, while ending at {:?}",
                 block_pos[best_reg], int_end
             );
@@ -880,7 +880,7 @@ fn allocate_blocked_reg<F: Function>(
                     if let Some(reg) = int.location.reg() {
                         if reg == best_reg {
                             // spill it!
-                            trace!("allocate_blocked_reg: split and spill active stolen reg");
+                            debug!("allocate_blocked_reg: split and spill active stolen reg");
                             split_and_spill(state, int_id, start_pos);
                             break;
                         }
@@ -1034,7 +1034,7 @@ fn next_pos(mut pos: InstPoint) -> InstPoint {
 fn split_and_spill<F: Function>(state: &mut State<F>, id: IntId, split_pos: InstPoint) {
     let child = match last_use(&state.intervals.get(id), split_pos, &state.reg_uses) {
         Some(last_use) => {
-            trace!(
+            debug!(
                 "split_and_spill {:?}: spill between {:?} and {:?}",
                 id, last_use, split_pos
             );
@@ -1054,7 +1054,7 @@ fn split_and_spill<F: Function>(state: &mut State<F>, id: IntId, split_pos: Inst
         None => {
             // The current interval has no uses before the split position, it can
             // safely be spilled.
-            trace!(
+            debug!(
                 "split_and_spill {:?}: spilling it since no uses before split position",
                 id
             );
@@ -1066,7 +1066,7 @@ fn split_and_spill<F: Function>(state: &mut State<F>, id: IntId, split_pos: Inst
     // Split until the next register use.
     match next_use(&state.intervals.get(child), split_pos, &state.reg_uses) {
         Some(next_use_pos) => {
-            trace!(
+            debug!(
                 "split spilled interval before next use @ {:?}",
                 next_use_pos
             );
@@ -1079,7 +1079,7 @@ fn split_and_spill<F: Function>(state: &mut State<F>, id: IntId, split_pos: Inst
     }
 
     // In both cases, the spilled child interval can remain on the stack.
-    trace!("spilled split child {:?} silently expires", child);
+    debug!("spilled split child {:?} silently expires", child);
 }
 
 /// Try to find a (use) position where to split the interval until the next point at which it
@@ -1145,7 +1145,7 @@ fn try_split_regs<F: Function>(
 /// in place. The child interval starts after (including) at_pos.
 #[inline(never)]
 fn split<F: Function>(state: &mut State<F>, id: IntId, at_pos: InstPoint) -> IntId {
-    trace!("split {:?} at {:?}", id, at_pos);
+    debug!("split {:?} at {:?}", id, at_pos);
     trace!("interval: {}", state.intervals.get(id));
 
     let int = state.intervals.get(id);

--- a/lib/src/linear_scan/mod.rs
+++ b/lib/src/linear_scan/mod.rs
@@ -4,7 +4,7 @@
 //!   Optimized Interval Splitting in a Linear Scan Register Allocator,
 //!     by Wimmer et al., 2005
 
-use log::{info, log_enabled, trace, Level};
+use log::{log_enabled, trace, Level};
 
 use std::env;
 use std::fmt;
@@ -716,7 +716,7 @@ fn set_registers<F: Function>(
     stackmap_request: Option<&StackmapRequestInfo>,
     stackmaps: &[Vec<SpillSlot>],
 ) -> Result<Set<RealReg>, CheckerErrors> {
-    info!("set_registers");
+    trace!("set_registers");
 
     let mut clobbered_registers = Set::empty();
 
@@ -885,7 +885,7 @@ fn apply_registers<F: Function>(
     use_checker: bool,
     stackmap_request: Option<&StackmapRequestInfo>,
 ) -> Result<RegAllocResult<F>, RegAllocError> {
-    info!("apply_registers");
+    trace!("apply_registers");
 
     let stackmaps = compute_stackmaps(virtual_intervals, stackmap_request.clone());
 

--- a/lib/src/linear_scan/resolve_moves.rs
+++ b/lib/src/linear_scan/resolve_moves.rs
@@ -7,7 +7,7 @@ use crate::{
     Function, RealReg, Reg, SpillSlot, TypedIxVec, VirtualReg, Writable,
 };
 
-use log::{debug, info, trace};
+use log::trace;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 use std::fmt;
@@ -96,7 +96,7 @@ fn resolve_moves_in_block<F: Function>(
 
                     Location::Reg(from_rreg) => {
                         if from_rreg != rreg {
-                            debug!(
+                            trace!(
                                 "inblock fixup: {:?} move {:?} -> {:?} at {:?}",
                                 interval.id, from_rreg, rreg, at_inst
                             );
@@ -105,7 +105,7 @@ fn resolve_moves_in_block<F: Function>(
                     }
 
                     Location::Stack(spill) => {
-                        debug!(
+                        trace!(
                             "inblock fixup: {:?} reload {:?} -> {:?} at {:?}",
                             interval.id, spill, rreg, at_inst
                         );
@@ -129,7 +129,7 @@ fn resolve_moves_in_block<F: Function>(
                     Location::None => unreachable!(),
 
                     Location::Reg(rreg) => {
-                        debug!(
+                        trace!(
                             "inblock fixup: {:?} spill {:?} -> {:?} at {:?}",
                             interval.id, rreg, spill, at_inst
                         );
@@ -372,7 +372,7 @@ fn resolve_moves_across_blocks<F: Function>(
                         if cur_rreg == succ_rreg {
                             continue;
                         }
-                        debug!(
+                        trace!(
                           "boundary fixup: move {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           cur_rreg,
                           succ_rreg,
@@ -387,7 +387,7 @@ fn resolve_moves_across_blocks<F: Function>(
                     }
 
                     (Location::Reg(cur_rreg), Location::Stack(spillslot)) => {
-                        debug!(
+                        trace!(
                           "boundary fixup: spill {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           cur_rreg,
                           spillslot,
@@ -402,7 +402,7 @@ fn resolve_moves_across_blocks<F: Function>(
                     }
 
                     (Location::Stack(spillslot), Location::Reg(rreg)) => {
-                        debug!(
+                        trace!(
                           "boundary fixup: reload {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           spillslot,
                           rreg,
@@ -463,7 +463,7 @@ fn resolve_moves_across_blocks<F: Function>(
         parallel_move_map.clear();
     }
 
-    debug!("");
+    trace!("");
 }
 
 #[inline(never)]
@@ -477,7 +477,7 @@ pub(crate) fn run<F: Function>(
     spill_slot: &mut u32,
     scratches_by_rc: &[Option<RealReg>],
 ) -> Vec<InstToInsertAndExtPoint> {
-    info!("resolve_moves");
+    trace!("resolve_moves");
 
     // Keep three lists of moves to insert:
     // - moves across blocks, that must happen at the start of blocks,

--- a/lib/src/linear_scan/resolve_moves.rs
+++ b/lib/src/linear_scan/resolve_moves.rs
@@ -7,7 +7,7 @@ use crate::{
     Function, RealReg, Reg, SpillSlot, TypedIxVec, VirtualReg, Writable,
 };
 
-use log::trace;
+use log::{debug, info, trace};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
 use std::fmt;
@@ -96,7 +96,7 @@ fn resolve_moves_in_block<F: Function>(
 
                     Location::Reg(from_rreg) => {
                         if from_rreg != rreg {
-                            trace!(
+                            debug!(
                                 "inblock fixup: {:?} move {:?} -> {:?} at {:?}",
                                 interval.id, from_rreg, rreg, at_inst
                             );
@@ -105,7 +105,7 @@ fn resolve_moves_in_block<F: Function>(
                     }
 
                     Location::Stack(spill) => {
-                        trace!(
+                        debug!(
                             "inblock fixup: {:?} reload {:?} -> {:?} at {:?}",
                             interval.id, spill, rreg, at_inst
                         );
@@ -129,7 +129,7 @@ fn resolve_moves_in_block<F: Function>(
                     Location::None => unreachable!(),
 
                     Location::Reg(rreg) => {
-                        trace!(
+                        debug!(
                             "inblock fixup: {:?} spill {:?} -> {:?} at {:?}",
                             interval.id, rreg, spill, at_inst
                         );
@@ -372,7 +372,7 @@ fn resolve_moves_across_blocks<F: Function>(
                         if cur_rreg == succ_rreg {
                             continue;
                         }
-                        trace!(
+                        debug!(
                           "boundary fixup: move {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           cur_rreg,
                           succ_rreg,
@@ -387,7 +387,7 @@ fn resolve_moves_across_blocks<F: Function>(
                     }
 
                     (Location::Reg(cur_rreg), Location::Stack(spillslot)) => {
-                        trace!(
+                        debug!(
                           "boundary fixup: spill {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           cur_rreg,
                           spillslot,
@@ -402,7 +402,7 @@ fn resolve_moves_across_blocks<F: Function>(
                     }
 
                     (Location::Stack(spillslot), Location::Reg(rreg)) => {
-                        trace!(
+                        debug!(
                           "boundary fixup: reload {:?} -> {:?} at {:?} for {:?} between {:?} and {:?}",
                           spillslot,
                           rreg,
@@ -463,7 +463,7 @@ fn resolve_moves_across_blocks<F: Function>(
         parallel_move_map.clear();
     }
 
-    trace!("");
+    debug!("");
 }
 
 #[inline(never)]
@@ -477,7 +477,7 @@ pub(crate) fn run<F: Function>(
     spill_slot: &mut u32,
     scratches_by_rc: &[Option<RealReg>],
 ) -> Vec<InstToInsertAndExtPoint> {
-    trace!("resolve_moves");
+    debug!("resolve_moves");
 
     // Keep three lists of moves to insert:
     // - moves across blocks, that must happen at the start of blocks,


### PR DESCRIPTION
We embed wasmtime in [Substrate](https://github.com/paritytech/substrate). We are looking to upgrade to 0.27 which seems to be using the new backend, even for x64 (🎉  btw!). 

We've noticed a problem though. In Substrate we have a logger enabled and by default it uses `info!` to communicate information mostly used for node operators. After the upgrade though there are logging from regalloc. 

I think we can mute the `regalloc` on our side in the logger configuration. However, from what I understand, libraries should strive away from using `info!`. Instead, they should restrict themselves to be under `debug!` and `trace!`. 

Therefore, I figured that I would send a naive PR here to demote all the `info!` to `debug!`. I understand that this may not be appropriate: let me know if I can change something in this PR or we should just silence regalloc on our part.
