### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
       run: cargo build
     - name: Run tests
       run: cargo test --all --verbose
+    # make sure code builds in release mode as well
+    - run: cargo check --release
 
   # Lint dependency graph for security advisories, duplicate versions, and
   # incompatible licences.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build
     - name: Run tests
       run: cargo test --all --verbose
     # make sure code builds in release mode as well

--- a/lib/src/linear_scan/analysis.rs
+++ b/lib/src/linear_scan/analysis.rs
@@ -106,7 +106,6 @@ impl RangeFrag {
     }
 
     #[inline(always)]
-    #[cfg(debug_assertions)]
     pub(crate) fn contains(&self, inst: &InstPoint) -> bool {
         self.first <= *inst && *inst <= self.last
     }


### PR DESCRIPTION
Currently this crate fails to build with `--release` due to a missing
method, and this commit fixes that! I believe this was an accidental
regression from #125.