### PR TITLE
Release 0.0.32.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.32"
 authors = ["The Regalloc.rs Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
This release pulls in #128 in order to fix bytecodealliance/wasmtime#3441.