### PR TITLE
Release 0.0.33

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regalloc"
-version = "0.0.32"
+version = "0.0.33"
 authors = ["The Regalloc.rs Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
The log fix from #130 causes a large speedup when the logger implementation correctly implements `Log::enabled`, so I'm proposing to do a patch release here. Should be pretty straightforward to get in wasmtime as well, also it might not even be necessary, as this is a patch version and Cargo should pick it up automatically (? in theory at least).