### PR TITLE
Make `WritableBase` public and add a blanket implementation

### DIFF
--- a/lib/src/data_structures.rs
+++ b/lib/src/data_structures.rs
@@ -901,10 +901,6 @@ impl Reg {
 /// create a distinction, at the Rust type level, between a plain "register"
 /// and a "writable register".
 ///
-/// Only structs that implement the `WritableBase` trait can be wrapped with
-/// `Writable`. These are the Reg, RealReg and VirtualReg data structures only,
-/// since `WritableBase` is not exposed to end users.
-///
 /// Writable<..> can be used by the client to ensure that, internally, it only
 /// generates instructions that write to registers that should be written. The
 /// `InstRegUses` below, which must be implemented for every instruction,
@@ -927,9 +923,10 @@ pub trait WritableBase:
 {
 }
 
-impl WritableBase for Reg {}
-impl WritableBase for RealReg {}
-impl WritableBase for VirtualReg {}
+impl<T> WritableBase for T where
+    T: Copy + Clone + PartialEq + Eq + Hash + PartialOrd + Ord + fmt::Debug
+{
+}
 
 impl<R> Writable<R> {
     /// Create a Writable<R> from an R. The client should carefully audit where

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -60,6 +60,7 @@ pub use crate::data_structures::RealReg;
 pub use crate::data_structures::VirtualReg;
 
 pub use crate::data_structures::Writable;
+pub use crate::data_structures::WritableBase;
 
 pub use crate::data_structures::NUM_REG_CLASSES;
 


### PR DESCRIPTION
The blanket implementation is for any type that implements all of
`WritableBase`'s super traits.

This allows us to do things like create newtype wrappers for different register
classes (e.g. `Gpr` or `Xmm` on x86_64) and still use these newtype wrappers
with `Writable` (e.g. `Writable<Xmm>`).

r? @cfallin 