### PR TITLE
Deprecate this crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 regalloc.rs
 ===
 
-⚠ This project has been deprecated in favor of the [regalloc2](https://github.com/cfallin/regalloc2), which is maintained and expected to be faster. No security updates will be made, and contributions will be disabled.
+⚠ This project has been deprecated in favor of the [regalloc2](https://github.com/bytecodealliance/regalloc2), which is maintained and expected to be faster. No security updates will be made, and contributions will be disabled.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 regalloc.rs
 ===
 
+⚠ This project has been deprecated in favor of the [regalloc2](https://github.com/cfallin/regalloc2), which is maintained and expected to be faster. No security updates will be made, and contributions will be disabled.
+
+---
+
 A work-in-progress modular register allocation algorithm, implemented so as to
 be used in [Cranelift](https://github.com/bytecodealliance/wasmtime/tree/main/cranelift).
 


### PR DESCRIPTION
We are deprecating this crate, since regalloc2 is more modern, maintained and expected to be faster both in compile times and have better generated code quality.

@cfallin If you agree with this, once we've merged this, I'll archive this repository and disable pull requests/issues. If there's any interesting issues that also makes sense for regalloc2, we can re-open them in regalloc2's issue tracker.